### PR TITLE
[Feature] ITEM - 마이페이지 내 거래내역 조회 API 구현

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/PriceProposeResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/PriceProposeResponse.java
@@ -9,6 +9,8 @@ import com.ducks.goodsduck.commons.model.enums.PriceProposeStatus;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @NoArgsConstructor
 public class PriceProposeResponse {
@@ -18,6 +20,7 @@ public class PriceProposeResponse {
     private ItemSimpleDto item;
     private int proposedPrice;
     private PriceProposeStatus status;
+    private LocalDateTime createdAt;
 
     public PriceProposeResponse (PricePropose pricePropose) {
         this.priceProposeId = pricePropose.getId();
@@ -25,6 +28,7 @@ public class PriceProposeResponse {
         this.item = new ItemSimpleDto();
         this.proposedPrice = pricePropose.getPrice();
         this.status = pricePropose.getStatus();
+        this.createdAt = pricePropose.getCreatedAt();
     }
 
     public PriceProposeResponse (User user, Item item, PricePropose pricePropose) {
@@ -33,5 +37,6 @@ public class PriceProposeResponse {
         this.item = new ItemSimpleDto(item);
         this.proposedPrice = pricePropose.getPrice();
         this.status = pricePropose.getStatus();
+        this.createdAt = pricePropose.getCreatedAt();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemSummaryDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemSummaryDto.java
@@ -1,0 +1,38 @@
+package com.ducks.goodsduck.commons.model.dto.item;
+
+import com.ducks.goodsduck.commons.model.dto.ImageDto;
+import com.ducks.goodsduck.commons.model.entity.Image;
+import com.ducks.goodsduck.commons.model.entity.Item;
+import com.ducks.goodsduck.commons.model.enums.TradeStatus;
+import com.ducks.goodsduck.commons.model.enums.TradeType;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class ItemSummaryDto {
+
+    private Long itemId;
+    private String name;
+    private Long price;
+    private TradeType tradeType;
+    private TradeStatus tradeStatus;
+    private LocalDateTime itemCreatedAt;
+    private ImageDto image;
+
+    public static ItemSummaryDto of (Item item, Image image) {
+        return new ItemSummaryDto(item, image);
+    }
+
+    public ItemSummaryDto(Item item, Image image) {
+        this.itemId = item.getId();
+        this.name = item.getName();
+        this.price = item.getPrice();
+        this.tradeType = item.getTradeType();
+        this.tradeStatus = item.getTradeStatus();
+        this.itemCreatedAt = item.getCreatedAt();
+        this.image = new ImageDto(image);
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.ducks.goodsduck.commons.repository;
 
+import com.ducks.goodsduck.commons.model.entity.Item;
+import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +14,5 @@ public interface ItemRepositoryCustom {
     Tuple findByItemId(Long itemId);
     List<Tuple> findAllWithUserItem(Long userId, Pageable pageable);
     Tuple findByIdWithUserItem(Long userId, Long itemId);
+    List<Tuple> findAllByUserIdAndTradeStatus(Long userId, TradeStatus status);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
@@ -1,10 +1,16 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.*;
+import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.alias.Alias;
 import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +31,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     private QIdolMember idolMember = QIdolMember.idolMember;
     private QIdolGroup idolGroup = QIdolGroup.idolGroup;
     private QCategoryItem categoryItem = QCategoryItem.categoryItem;
+    private QImage image = QImage.image;
 
     public ItemRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
@@ -104,6 +111,27 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 .where(item.id.eq(itemId))
                 .groupBy(item)
                 .fetchOne();
+    }
 
+    @Override
+    public List<Tuple> findAllByUserIdAndTradeStatus(Long userId, TradeStatus status) {
+
+        QImage subImage = new QImage("subImage");
+
+        JPQLQuery<Long> rankSubquery = JPAExpressions.select(subImage.count().add(1))
+                .from(subImage)
+                .where(subImage.id.lt(image.id).and(
+                        subImage.item.eq(image.item)
+                ));
+
+        return queryFactory.select(item, image)
+                .from(item)
+                .join(image).on(item.eq(image.item))
+                .where(item.user.id.eq(userId).and(
+                        item.tradeStatus.eq(status).and(
+                                rankSubquery.eq(1L)
+                        )
+                ))
+                .fetch();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
@@ -5,10 +5,9 @@ import com.ducks.goodsduck.commons.model.dto.item.ItemDetailResponse;
 import com.ducks.goodsduck.commons.model.dto.item.ItemUpdateRequest;
 import com.ducks.goodsduck.commons.model.dto.item.ItemUploadRequest;
 import com.ducks.goodsduck.commons.model.entity.*;
+import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.ducks.goodsduck.commons.repository.*;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.dsl.PathBuilder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -193,5 +192,9 @@ public class ItemService {
         int end = maxCount > count ? (int) count : maxCount;
 
         return new PageImpl(tupleToList.subList(start, end), pageable, count);
+    }
+
+    public List<Tuple> findMyItem(Long userId, TradeStatus status) {
+        return itemRepositoryCustom.findAllByUserIdAndTradeStatus(userId, status);
     }
 }


### PR DESCRIPTION
### 아래 이미지에 필요한 데이터를 불러오기 위한 API

![image](https://user-images.githubusercontent.com/59888684/126484289-915717cf-4139-4230-b477-224de2205b12.png)

- querydsl을 이용하였으며, 아이템-이미지 일대다 관계에서 발생하는 N+1 쿼리 발생 문제 해결
  - 이미지를 불러오는 서브 쿼리에 랭킹을 적용하여, 가장 빠른 id에 해당하는 이미지를 같이 불러오도록 함(썸네일 이미지)