### PR TITLE
[Feature] 아이템 거래 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
@@ -159,22 +159,38 @@ public class ItemController {
     public ApiResult<List<ItemSummaryDto>> getMyItemList(HttpServletRequest request, @RequestParam("tradeStatus") String tradeStatus) {
 
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
-        try {
-            TradeStatus status = TradeStatus.valueOf(tradeStatus.toUpperCase());
-            return OK(itemService.findMyItem(userId, status)
-                    .stream()
-                    .map(tuple -> {
-                        Item item = tuple.get(0, Item.class);
-                        Image image = tuple.get(1, Image.class);
-                        return ItemSummaryDto.of(item, image);
-                    })
-                    .collect(Collectors.toList()));
+        TradeStatus status;
 
+        try {
+            status = TradeStatus.valueOf(tradeStatus.toUpperCase());
         } catch (IllegalArgumentException e) {
             log.debug("Exception occurred in parsing tradeStatus: {}", e.getMessage(), e);
             throw new IllegalArgumentException("There is no tradeStatus inserted");
         }
 
+        return OK(itemService.findMyItem(userId, status)
+                .stream()
+                .map(tuple -> {
+                    Item item = tuple.get(0, Item.class);
+                    Image image = tuple.get(1, Image.class);
+                    return ItemSummaryDto.of(item, image);
+                })
+                .collect(Collectors.toList()));
     }
 
+    @ApiOperation(value = "아이템 거래 상태 변경 API")
+    @PatchMapping("/item/{item_id}/tradeStatus")
+    public ApiResult updateMyItemTradeStatus(HttpServletRequest request, @PathVariable("item_id") Long item_id, @RequestParam("tradeStatus") String tradeStatus) {
+        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        TradeStatus status;
+
+        try {
+            status = TradeStatus.valueOf(tradeStatus.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.debug("Exception occurred in parsing tradeStatus: {}", e.getMessage(), e);
+            throw new IllegalArgumentException("There is no tradeStatus inserted");
+        }
+
+        return OK(itemService.updateTradeStatus(userId, item_id, status));
+    }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/enums/TradeStatus.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/enums/TradeStatus.java
@@ -4,7 +4,7 @@ public enum TradeStatus {
     BUYING("구매중"),
     SELLING("판매중"),
     RESERVING("예약중"),
-    COMPLETE("판매완료");
+    COMPLETE("거래완료");
 
     private String korName;
 

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
@@ -1,9 +1,7 @@
 package com.ducks.goodsduck.commons.repository;
 
-import com.ducks.goodsduck.commons.model.entity.Item;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.querydsl.core.Tuple;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +13,5 @@ public interface ItemRepositoryCustom {
     List<Tuple> findAllWithUserItem(Long userId, Pageable pageable);
     Tuple findByIdWithUserItem(Long userId, Long itemId);
     List<Tuple> findAllByUserIdAndTradeStatus(Long userId, TradeStatus status);
+    long updateTradeStatus(Long itemId, TradeStatus status);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
@@ -134,4 +134,12 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 ))
                 .fetch();
     }
+
+    @Override
+    public long updateTradeStatus(Long itemId, TradeStatus status) {
+        return queryFactory.update(item)
+                .set(item.tradeStatus, status)
+                .where(item.id.eq(itemId))
+                .execute();
+    }
 }


### PR DESCRIPTION
### PATCH /api/v1/item/{item_id}/tradeStatus
request header : jwt
query parameter : tradeStatus (`selling`, `buying`, `reserving`, `complete`)

상태(tradeStatus) 종류 : `판매중`/`구매중`, `예약중`, `거래완료`

- 판매(TradeType==SELL) 게시글은 구매중 상태로 업데이트할 수 없음
- 구매(TradeType==BUY) 게시글은 판매중 상태로 업데이트할 수 없음
- `거래완료` 상태에서는 다른 상태로 변경 불가능 (예외 발생)