### PR TITLE
[Feature] 내 아이템 목록(거래내역) 조회 API 변경

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/aop/CheckJwtAspect.java
+++ b/src/main/java/com/ducks/goodsduck/commons/aop/CheckJwtAspect.java
@@ -35,9 +35,9 @@ public class CheckJwtAspect {
         Long userId = userService.checkLoginStatus(jwt);
 
         // HINT: jwt의 payloads를 통해 userId를 읽었을 경우 UnAuthorized 에러 반환
-//        if (userId.equals(-1L)) {
-//            return ApiResult.ERROR("There is no jwt or not be able to get payloads.", HttpStatus.UNAUTHORIZED);
-//        }
+        if (userId.equals(-1L)) {
+            return ApiResult.ERROR("There is no jwt or not be able to get payloads.", HttpStatus.UNAUTHORIZED);
+        }
 
         request.setAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS, userId);
 

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/ImageDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/ImageDto.java
@@ -2,8 +2,10 @@ package com.ducks.goodsduck.commons.model.dto;
 
 import com.ducks.goodsduck.commons.model.entity.Image;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class ImageDto {
 
     private String originName;

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemSummaryDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemSummaryDto.java
@@ -1,7 +1,6 @@
 package com.ducks.goodsduck.commons.model.dto.item;
 
 import com.ducks.goodsduck.commons.model.dto.ImageDto;
-import com.ducks.goodsduck.commons.model.entity.Image;
 import com.ducks.goodsduck.commons.model.entity.Item;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.ducks.goodsduck.commons.model.enums.TradeType;
@@ -22,17 +21,30 @@ public class ItemSummaryDto {
     private LocalDateTime itemCreatedAt;
     private ImageDto image;
 
-    public static ItemSummaryDto of (Item item, Image image) {
+    public static ItemSummaryDto of (Item item, ImageDto image) {
         return new ItemSummaryDto(item, image);
     }
 
-    public ItemSummaryDto(Item item, Image image) {
+    public static ItemSummaryDto of (Item item) {
+        return new ItemSummaryDto(item);
+    }
+
+    public ItemSummaryDto(Item item) {
         this.itemId = item.getId();
         this.name = item.getName();
         this.price = item.getPrice();
         this.tradeType = item.getTradeType();
         this.tradeStatus = item.getTradeStatus();
         this.itemCreatedAt = item.getCreatedAt();
-        this.image = new ImageDto(image);
+    }
+
+    public ItemSummaryDto(Item item, ImageDto image) {
+        this.itemId = item.getId();
+        this.name = item.getName();
+        this.price = item.getPrice();
+        this.tradeType = item.getTradeType();
+        this.tradeStatus = item.getTradeStatus();
+        this.itemCreatedAt = item.getCreatedAt();
+        this.image = image;
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemTradeStatusUpdateRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemTradeStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.ducks.goodsduck.commons.model.dto.item;
+
+import lombok.Data;
+
+@Data
+public class ItemTradeStatusUpdateRequest {
+
+    private String tradeStatus;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.ducks.goodsduck.commons.repository;
 
+import com.ducks.goodsduck.commons.model.entity.Item;
+import com.ducks.goodsduck.commons.model.entity.UserIdolGroup;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Pageable;
@@ -10,7 +12,7 @@ import java.util.List;
 @Repository
 public interface ItemRepositoryCustom {
     Tuple findByItemId(Long itemId);
-    List<Tuple> findAllWithUserItem(Long userId, Pageable pageable);
+    List<Tuple> findAllWithUserItemIdolGroup(Long userId, List<UserIdolGroup> userIdolGroups, Pageable pageable);
     Tuple findByIdWithUserItem(Long userId, Long itemId);
     List<Tuple> findAllByUserIdAndTradeStatus(Long userId, TradeStatus status);
     long updateTradeStatus(Long itemId, TradeStatus status);

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
@@ -126,10 +126,11 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
 
         return queryFactory.select(item, image)
                 .from(item)
-                .join(image).on(item.eq(image.item))
+                .leftJoin(image).on(image.item.id.eq(item.id))
                 .where(item.user.id.eq(userId).and(
-                        item.tradeStatus.eq(status).and(
-                                rankSubquery.eq(1L)
+                        item.tradeStatus.eq(status)
+                                .and(
+                                rankSubquery.in(1L, null)
                         )
                 ))
                 .fetch();


### PR DESCRIPTION
### 변경사항
- 해당 API: `GET` `/api/v1/mypage/items`
- 변경 전: `QueryParameter`로 `TradeStatus` 리스트를 입력 받아서 `SELLING,BUYING,RESERVING,COMPLETE` 상태에 있는 내 아이템 목록 조회. `SELLING,` `BUYING` 상태에 **`RESERVING` 상태의 경우가 모두 들어간다는게 문제**.
- 변경 후: `QueryParameter`로 단일 TradeStatus를 입력 받아서 SELLING,BUYING,COMPLETE에 따라 아이템을 조회함. `SELLING`의 경우, `TradeType`이 `SELL`인 조건이 걸리고, `BUYING`의 경우, `BUY`인 조건에 걸리는 변화가 있음.
- 그 밖에 이미지가 등록되지 않은 아이템의 경우 불러오지 못했는데, 이 점을 해결함.