### PR TITLE
[feat] 리뷰 API(Create, Read) 추가

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
@@ -38,7 +38,7 @@ public class ReviewController {
     @PostMapping("/v1/users/reviews")
     @ApiOperation("채팅방 ID를 통해 특정 유저에 대한 리뷰 남기기")
     public ApiResult<Boolean> sendReview(HttpServletRequest request,
-                                         @RequestBody ReviewRequest reviewRequest) {
+                                         @RequestBody ReviewRequest reviewRequest) throws IllegalAccessException {
         var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         reviewService.saveReview(userId, reviewRequest);
         return OK(true);

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
@@ -1,0 +1,53 @@
+package com.ducks.goodsduck.commons.controller;
+
+import com.ducks.goodsduck.commons.model.dto.ReviewRequest;
+import com.ducks.goodsduck.commons.model.dto.ApiResult;
+import com.ducks.goodsduck.commons.model.dto.ReviewResponse;
+import com.ducks.goodsduck.commons.service.ReviewService;
+import com.ducks.goodsduck.commons.util.PropertyUtil;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+import static com.ducks.goodsduck.commons.model.dto.ApiResult.OK;
+
+@RestController
+@RequestMapping("/api")
+@Slf4j
+@Api(tags = "유저에 대한 리뷰 APIs")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @GetMapping("/v1/users/reviews")
+    @ApiOperation("마이 페이지에서 리뷰 목록 조회")
+    public ApiResult<List<ReviewResponse>> getMyReviews(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(reviewService.getReviewsOfLoginUser(userId));
+    }
+
+    @PostMapping("/v1/users/reviews")
+    @ApiOperation("채팅방 ID를 통해 특정 유저에 대한 리뷰 남기기")
+    public ApiResult<Boolean> sendReview(HttpServletRequest request,
+                                         @RequestBody ReviewRequest reviewRequest) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        reviewService.saveReview(userId, reviewRequest);
+        return OK(true);
+    }
+
+    @GetMapping("/v1/items/{itemId}/users/reviews")
+    @ApiOperation("특정 아이템 게시물 작성자에 대한 리뷰 목록 조회")
+    public ApiResult<List<ReviewResponse>> getReviews(@PathVariable("itemId") Long itemId) {
+
+        return OK(reviewService.getReviewsOfItemOwner(itemId));
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewRequest.java
@@ -1,0 +1,13 @@
+package com.ducks.goodsduck.commons.model.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ReviewRequest {
+
+    private Long itemId;
+    private String chatRoomId;
+    private String content;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewResponse.java
@@ -1,0 +1,24 @@
+package com.ducks.goodsduck.commons.model.dto;
+
+import com.ducks.goodsduck.commons.model.entity.Review;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class ReviewResponse {
+
+    private String writerImageUrl;
+    private String writerNickName;
+    private String content;
+    private LocalDateTime createdAt;
+
+    public ReviewResponse(Review review) {
+        this.writerImageUrl = review.getUser().getImageUrl();
+        this.writerNickName = review.getUser().getNickName();
+        this.content = review.getContent();
+        this.createdAt = review.getCreatedAt();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepository.java
@@ -1,6 +1,7 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.Item;
+import com.ducks.goodsduck.commons.model.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
@@ -46,4 +46,6 @@ public interface ItemRepositoryCustom {
     List<Tuple> findAllByFilterWithUserItem(Long userId, ItemFilterDto itemFilterDto, Pageable pageable);
     List<Tuple> findAllByFilterWithUserItemV2(Long userId, ItemFilterDto itemFilterDto, Pageable pageable, String keyword);
     List<Tuple> findAllByFilterWithUserItemV3(Long userId, ItemFilterDto itemFilterDto, Long itemId);
+
+    Tuple findItemAndUserByItemId(Long itemId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustomImpl.java
@@ -600,4 +600,13 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                         subImage.item.eq(image.item)
                 ));
     }
+
+    @Override
+    public Tuple findItemAndUserByItemId(Long itemId) {
+        return queryFactory
+                .select(item, item.user)
+                .from(item)
+                .where(item.id.eq(itemId))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepository.java
@@ -2,9 +2,8 @@ package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
+@Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findByUserId(Long userId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepository.java
@@ -1,0 +1,10 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByUserId(Long userId);
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.entity.Item;
+import com.querydsl.core.Tuple;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ReviewRepositoryCustom {
+    boolean existsByItemIdAndUserId(Long itemId, Long senderId);
+    List<Tuple> findInItems(List<Item> items);
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,44 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.entity.*;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+@Repository
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    private QReview review = QReview.review;
+    private QItem item = QItem.item;
+    private QUser user = QUser.user;
+
+    public ReviewRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public boolean existsByItemIdAndUserId(Long itemId, Long senderId) {
+        long fetchCount = queryFactory
+                .select(review)
+                .from(review)
+                .where(review.item.id.eq(itemId).and(
+                        review.user.id.eq(senderId)
+                )).fetchCount();
+        return fetchCount > 0L;
+    }
+
+    @Override
+    public List<Tuple> findInItems(List<Item> items) {
+        return queryFactory
+                .select(review, user)
+                .from(review)
+                .join(user).on(review.user.eq(user))
+                .where(review.item.in(items))
+                .fetch();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepository.java
@@ -4,6 +4,8 @@ import com.ducks.goodsduck.commons.model.entity.UserChat;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserChatRepository extends JpaRepository<UserChat, Long> {
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
@@ -11,4 +11,5 @@ public interface UserChatRepositoryCustom {
 
     List<UserChat> findAllByChatId(String chatId);
     List<Tuple> findChatAndItemByUserId(Long userId);
+    Tuple findReceieverAndItemByChatId(String chatId, Long senderId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
@@ -8,8 +8,7 @@ import java.util.List;
 
 @Repository
 public interface UserChatRepositoryCustom {
-
     List<UserChat> findAllByChatId(String chatId);
     List<Tuple> findChatAndItemByUserId(Long userId);
-    Tuple findReceieverAndItemByChatId(String chatId, Long senderId);
+    Tuple findSenderAndItemByChatIdAndUserId(String chatId, Long senderId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
@@ -40,4 +40,13 @@ public class UserChatRepositoryCustomImpl implements UserChatRepositoryCustom {
                 .where(userChat.user.id.eq(userId))
                 .fetch();
     }
+
+    @Override
+    public Tuple findReceieverAndItemByChatId(String chatId, Long senderId) {
+        return queryFactory
+                .select(userChat.user, userChat.item)
+                .from(userChat)
+                .where(userChat.chat.id.eq(chatId).and(userChat.user.id.ne(senderId)))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
@@ -42,11 +42,12 @@ public class UserChatRepositoryCustomImpl implements UserChatRepositoryCustom {
     }
 
     @Override
-    public Tuple findReceieverAndItemByChatId(String chatId, Long senderId) {
+    public Tuple findSenderAndItemByChatIdAndUserId(String chatId, Long senderId) {
         return queryFactory
                 .select(userChat.user, userChat.item)
                 .from(userChat)
-                .where(userChat.chat.id.eq(chatId).and(userChat.user.id.ne(senderId)))
+                .where(userChat.chat.id.eq(chatId)
+                        .and(userChat.user.id.eq(senderId)))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/service/NotificationService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/NotificationService.java
@@ -41,6 +41,11 @@ public class NotificationService {
             notificationRepository.save(notification);
 
             List<String> registrationTokens = deviceRepositoryCustom.getRegistrationTokensByUserId(receiverUserId);
+
+            if (registrationTokens.isEmpty()) {
+                log.debug("Device for notification not founded.");
+                return;
+            }
             var notificationResponse = new NotificationResponse(notification);
             var notificationMessage = notificationResponse.getMessage();
 

--- a/src/main/java/com/ducks/goodsduck/commons/service/ReviewService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ReviewService.java
@@ -1,0 +1,73 @@
+package com.ducks.goodsduck.commons.service;
+
+import com.ducks.goodsduck.commons.model.dto.ReviewRequest;
+import com.ducks.goodsduck.commons.model.dto.ReviewResponse;
+import com.ducks.goodsduck.commons.model.entity.Item;
+import com.ducks.goodsduck.commons.model.entity.Review;
+import com.ducks.goodsduck.commons.model.entity.User;
+import com.ducks.goodsduck.commons.repository.*;
+import com.querydsl.core.Tuple;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.NoResultException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final UserChatRepositoryCustom userChatRepositoryCustom;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ItemRepositoryCustom itemRepositoryCustom;
+
+    public ReviewService(ReviewRepository reviewRepository, UserRepository userRepository, UserChatRepositoryCustomImpl userChatRepositoryCustom, ItemRepository itemRepository, ItemRepositoryCustomImpl itemRepositoryCustom) {
+        this.reviewRepository = reviewRepository;
+        this.userRepository = userRepository;
+        this.userChatRepositoryCustom = userChatRepositoryCustom;
+        this.itemRepository = itemRepository;
+        this.itemRepositoryCustom = itemRepositoryCustom;
+    }
+
+
+    public Optional<Review> saveReview(Long senderId, ReviewRequest reviewRequest) {
+
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> {
+                    throw new NoResultException("User not founded.");
+                });
+
+        Tuple receieverAndItem = userChatRepositoryCustom.findReceieverAndItemByChatId(reviewRequest.getChatRoomId(), senderId);
+
+        Item tradedItem = receieverAndItem.get(0, Item.class);
+        User receiver = receieverAndItem.get(1, User.class);
+
+        return Optional.ofNullable(reviewRepository.save(new Review(receiver, tradedItem, reviewRequest.getContent())));
+    }
+
+    public List<ReviewResponse> getReviewsOfItemOwner(Long itemId) {
+
+        itemRepository.findById(itemId);
+
+        Tuple itemAndUser = itemRepositoryCustom.findItemAndUserByItemId(itemId);
+
+        Item item = itemAndUser.get(0, Item.class);
+        User user = itemAndUser.get(1, User.class);
+
+        return reviewRepository.findByUserId(user.getId())
+                .stream()
+                .map(review -> new ReviewResponse(review))
+                .collect(Collectors.toList());
+    }
+
+    public List<ReviewResponse> getReviewsOfLoginUser(Long userId) {
+        return reviewRepository.findByUserId(userId)
+                .stream()
+                .map(review -> new ReviewResponse(review))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 리뷰 생성, 조회 API 구현
- POST `/api/v1/users/reviews` : jwt, 채팅방 ID를 통해 유저와 해당 채팅방에 참여한 인원인지 체크하고 상대방에게 리뷰를 등록합니다. (중복으로 작성하거나, 상대방과 같은 채팅방에 있지 않다면 불가합니다.)
- GET `/api/v1/users/reviews` : jwt를 통해 마이 페이지의 리뷰 목록을 조회합니다.
- GET `/api/v1/items/{itemId}/users/reviews` :  `itemId`를 통해 게시글 주인이 받은 리뷰 전체 목록을 받아옵니다. 현재는 다른 사람의 프로필을 볼 수 있는 경로가 아이템 상세보기 페이지 이므로, REST API는 이와 같이 구현하였습니다.