### PR TITLE
[Timmy] 아이템 검색 API 추가

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
@@ -178,7 +178,7 @@ public class ItemController {
     }
 
     @NoCheckJwt
-    @ApiOperation(value = "아이템 리스트 가져오기 in 홈 (V3 NoOffSet)")
+    @ApiOperation(value = "아이템 검색 (회원/비회원)")
     @GetMapping("/v1/items/search")
     @Transactional
     public ItemHomeResponseResult<List<ItemHomeResponse>> getSearchedItems(@RequestParam("keyword") String keyword,

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
@@ -178,6 +178,41 @@ public class ItemController {
     }
 
     @NoCheckJwt
+    @ApiOperation(value = "아이템 리스트 가져오기 in 홈 (V3 NoOffSet)")
+    @GetMapping("/v1/items/search")
+    @Transactional
+    public ItemHomeResponseResult<List<ItemHomeResponse>> getSearchedItems(@RequestParam("keyword") String keyword,
+                                                                           @RequestParam("itemId") Long itemId,
+                                                                           @RequestHeader("jwt") String jwt) {
+
+        int pageableSize = PropertyUtil.PAGEABLE_SIZE;
+        Boolean hasNext= false;
+        Long userId = userService.checkLoginStatus(jwt);
+
+        // HINT : 비회원에게 보여줄 홈
+        if(userId.equals(-1L)) {
+            List<ItemHomeResponse> itemList = itemService.getSearchedItemListForGuest(keyword, itemId);
+            if(itemList.size() == pageableSize + 1) {
+                hasNext = true;
+                itemList.remove(pageableSize);
+            }
+
+            return ItemHomeResponseResult.OK(hasNext, null, itemList);
+        }
+        // HINT : 회원에게 보여줄 홈
+        else {
+            User user = userRepository.findById(userId).get();
+            List<ItemHomeResponse> itemList = itemService.getSearchedItemListForUser(keyword, userId, itemId);
+            if(itemList.size() == pageableSize + 1) {
+                hasNext = true;
+                itemList.remove(pageableSize);
+            }
+
+            return ItemHomeResponseResult.OK(hasNext, new ItemDetailResponseUser(user), itemList);
+        }
+    }
+
+    @NoCheckJwt
     @ApiOperation(value = "아이템 리스트 가져오기 + 아이돌 그룹 필터링 in 홈")
     @GetMapping("/v1/items/filter")
     @Transactional

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemHomeResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/item/ItemHomeResponse.java
@@ -21,7 +21,7 @@ public class ItemHomeResponse {
     private List<ItemDetailResponseImage> images = new ArrayList<>();
     private Long price;
     private String tradeType;
-    private TradeStatus tradeStatus;
+    private String tradeStatus;
     private ItemDetailResponseIdol idolMember;
     private LocalDateTime itemCreatedAt;
     private Integer views;
@@ -38,7 +38,7 @@ public class ItemHomeResponse {
                 .collect(Collectors.toList());
         this.price = item.getPrice();
         this.tradeType = item.getTradeType().getKorName();
-        this.tradeStatus = item.getTradeStatus();
+        this.tradeStatus = item.getTradeStatus().getKorName();
         this.idolMember = new ItemDetailResponseIdol(item.getIdolMember());
         this.itemCreatedAt = item.getCreatedAt();
         this.views = item.getViews();

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ItemRepositoryCustom.java
@@ -48,4 +48,10 @@ public interface ItemRepositoryCustom {
     List<Tuple> findAllByFilterWithUserItemV3(Long userId, ItemFilterDto itemFilterDto, Long itemId);
 
     Tuple findItemAndUserByItemId(Long itemId);
+
+    // 비회원 - 검색 및 itemId 기반 Limit
+    List<Item> findByKeywordWithLimit(List<String> keywords, Long itemId);
+
+    // 회원 - 검색 및 itemId 기반 Limit
+    List<Tuple> findByKeywordWithUserItemAndLimit(Long userId, List<String> keywords, Long itemId);
 }


### PR DESCRIPTION
POST `/api/v1/items/search`
QueryString: `keyword(String)`, `itemId(Long)`

기존 경원 멘티가 구현한 홈에서의 아이템 리스트 조회 API에 검색 기능만 덧붙였습니다.
회원인 경우 좋아하는 아이돌에 대한 결과만 가져오던 부분이 전체를 대상으로 변경되었습니다.
쿼리스트링으로 keyword 값을 보내면 공백을 기준으로 파싱하여 조회한 결과를 반환합니다.