### PR TITLE
[Timmy] Notification, Review API 리팩토링

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
@@ -449,7 +449,7 @@ public class ItemController {
         User receiveUser = userItem.getItem().getUser();
         Notification userItemNotification = new Notification(receiveUser, userItem);
 
-        notificationService.sendMessage(receiveUser.getId(), userItemNotification);
+        notificationService.sendMessage(userItemNotification);
 
         return OK(new UserItemResponse(userItem));
     }

--- a/src/main/java/com/ducks/goodsduck/commons/controller/PriceProposeController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/PriceProposeController.java
@@ -1,6 +1,5 @@
 package com.ducks.goodsduck.commons.controller;
 
-import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
 import com.ducks.goodsduck.commons.model.entity.Notification;
 import com.ducks.goodsduck.commons.model.entity.User;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
@@ -53,7 +52,7 @@ public class PriceProposeController {
         PriceProposeResponse priceProposeResponse = priceProposeService.proposePrice(userId, itemId, priceProposeRequest.getPrice())
                 .orElseThrow(() -> new RuntimeException("Cannot propose the price."));
 
-        notificationService.sendMessage(priceProposeResponse.getReceiverId(), new Notification(user, priceProposeResponse));
+        notificationService.sendMessage(new Notification(user, priceProposeResponse));
 
         return OK(priceProposeResponse);
     }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/NotificationMessage.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/NotificationMessage.java
@@ -12,12 +12,12 @@ public class NotificationMessage {
     private String messageTitle;
     private String messageBody;
     private String messageUri;
-    private String imageUri;
+    private String iconUri;
 
-    public NotificationMessage(String messageTitle, String messageBody, String messageUri, String imageUri) {
+    public NotificationMessage(String messageTitle, String messageBody, String messageUri, String iconUri) {
         this.messageTitle = messageTitle;
         this.messageBody = messageBody;
         this.messageUri = messageUri;
-        this.imageUri = imageUri;
+        this.iconUri = iconUri;
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/NotificationResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/NotificationResponse.java
@@ -36,7 +36,7 @@ public class NotificationResponse {
         String body = String.format("%s님이 \"%s\" 굿즈", senderNickName,
                 itemTitle.length() < 12 ? notification.getItemName() : itemTitle.substring(12).concat("..."));
         String messageUri = "https://www.goods-duck.com"; // TODO
-        String imageUri = "https://goodsduck-s3.s3.ap-northeast-2.amazonaws.com/image/idol/artist_sf9.jpg"; // TODO
+        String iconUri = "https://goodsduck-s3.s3.ap-northeast-2.amazonaws.com/sample_goodsduck.png";
         switch (type) {
             case PRICE_PROPOSE:
                 body = body.concat(String.format("에 %s을 했어요. [%d원]", type.getKorName(), price));
@@ -50,21 +50,26 @@ public class NotificationResponse {
                 body = body.concat(String.format("에 %s를 보냈어요.", type.getKorName()));
                 break;
 
+            case REVIEW:
+                body = String.format("%s님이 %s를 남겼어요.", senderNickName, type.getKorName());
+                break;
+
             default:
                 body = body.concat(String.format("에 알림을 보냈어요."));
         }
+
         this.message = new NotificationMessage(
             title,
             body,
             messageUri,
-            imageUri
+            iconUri
         );
     }
 
     /**
      * @message 알림 유형별 구성
      *
-     * 굿즈덕 @가격제안(PricePropose) 알림
+     * 굿즈덕 @가격 제안(PricePropose) 알림
      * 제목: 굿즈덕 {notification.type} 알림
      * 내용: {user.nickname}님이 {item.name} 굿즈에 {notification.type}을 했어요. [{pricePropose.price}]
      *
@@ -75,6 +80,10 @@ public class NotificationResponse {
      * 굿즈덕 @채팅(Chat) 알림
      * 제목: 굿즈덕 {notification.type} 알림
      * 내용: {user.nickname}님이 {item.name} 굿즈에 {notification.type}을 보냈어요.
+     *
+     * 굿즈덕 @거래 리뷰(Review) 알림
+     * 제목: 굿즈덕 {notification.type} 알림
+     * 내용: {user.nickname}님이 {notification.type}을 남겼어요.
      */
 
 

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReviewRequest {
 
-    private Long itemId;
     private String chatRoomId;
     private String content;
+    private Integer score;
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/ReviewResponse.java
@@ -13,12 +13,14 @@ public class ReviewResponse {
     private String writerImageUrl;
     private String writerNickName;
     private String content;
+    private Integer score;
     private LocalDateTime createdAt;
 
     public ReviewResponse(Review review) {
         this.writerImageUrl = review.getUser().getImageUrl();
         this.writerNickName = review.getUser().getNickName();
         this.content = review.getContent();
+        this.score = review.getScore();
         this.createdAt = review.getCreatedAt();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/Notification.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/Notification.java
@@ -25,6 +25,8 @@ public class Notification {
 
     private String senderNickName;
     private String senderImageUri;
+
+    // HINT: Notification.REVIEW 인 경우, 빈 문자열
     private String itemName;
     private NotificationType type;
 
@@ -40,7 +42,7 @@ public class Notification {
         this.itemName = priceProposeResponse.getItem().getName();
         this.type = NotificationType.PRICE_PROPOSE;
         this.price = priceProposeResponse.getProposedPrice();
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = priceProposeResponse.getCreatedAt();
     }
 
     public Notification(User user, UserItem userItem) {
@@ -53,6 +55,15 @@ public class Notification {
         this.createdAt = LocalDateTime.now();
     }
 
+    public Notification(Review review, User receiver) {
+        this.user = receiver;
+        this.senderNickName = review.getUser().getNickName();
+        this.senderImageUri = review.getUser().getImageUrl();
+        this.itemName = "";
+        this.type = NotificationType.REVIEW;
+        this.createdAt = review.getCreatedAt();
+    }
+
     public Notification(User user, String senderNickname, String senderImageUri, String itemName, NotificationType type) {
         this.user = user;
         this.senderNickName = senderNickname;
@@ -62,7 +73,7 @@ public class Notification {
         this.createdAt = LocalDateTime.now();
     }
 
-    public Notification(User user, String senderNickname, String senderImageUri, String itemName,   NotificationType type, Integer price) {
+    public Notification(User user, String senderNickname, String senderImageUri, String itemName, NotificationType type, Integer price) {
         this.user = user;
         this.senderNickName = senderNickname;
         this.senderImageUri = senderImageUri;

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/Review.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/Review.java
@@ -24,17 +24,17 @@ public class Review {
     @JoinColumn(name = "USER_ID")
     private User user;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ITEM_ID")
-    private Item item;
+    private Long receiverId;
 
     private String content;
+    private Integer score;
     private LocalDateTime createdAt;
 
-    public Review(User user, Item item, String content) {
+    public Review(User user, Long receiverId, String content, Integer score) {
         this.user = user;
-        this.item = item;
+        this.receiverId = receiverId;
         this.content = content;
+        this.score = score;
         this.createdAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/enums/NotificationType.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/enums/NotificationType.java
@@ -1,9 +1,10 @@
 package com.ducks.goodsduck.commons.model.enums;
 
 public enum NotificationType {
-    PRICE_PROPOSE("가격제안"),
+    PRICE_PROPOSE("가격 제안"),
     USER_ITEM("찜"),
-    CHAT("채팅");
+    CHAT("채팅"),
+    REVIEW("거래 리뷰");
 
     private String korName;
 

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustom.java
@@ -1,17 +1,15 @@
 package com.ducks.goodsduck.commons.repository;
 
-import com.ducks.goodsduck.commons.model.entity.Item;
 import com.ducks.goodsduck.commons.model.entity.Review;
-import com.querydsl.core.Tuple;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ReviewRepositoryCustom {
-    boolean existsByItemIdAndUserId(Long itemId, Long senderId);
-    List<Tuple> findInItems(List<Item> items);
-    Long countByUserId(Long userId);
-    List<Review> findAllByUserId(Long userId);
-    Long countInItems(List<Item> items);
+    boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId);
+    Long countBySenderId(Long senderId);
+    List<Review> findByUserId(Long userId);
+    List<Review> findByReveiverId(Long receiverId);
+    Long countByReveiverId(Long receiverId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReviewRepositoryCustomImpl.java
@@ -1,7 +1,6 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.*;
-import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
@@ -14,36 +13,23 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     private QReview review = QReview.review;
-    private QItem item = QItem.item;
-    private QUser user = QUser.user;
 
     public ReviewRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
     }
 
     @Override
-    public boolean existsByItemIdAndUserId(Long itemId, Long senderId) {
-        long fetchCount = queryFactory
+    public boolean existsBySenderIdAndReceiverId(Long senderId, Long receiverId) {
+        return queryFactory
                 .select(review)
                 .from(review)
-                .where(review.item.id.eq(itemId).and(
-                        review.user.id.eq(senderId)
-                )).fetchCount();
-        return fetchCount > 0L;
+                .where(review.user.id.eq(senderId).and(
+                        review.receiverId.eq(receiverId)
+                )).fetchCount() > 0L;
     }
 
     @Override
-    public List<Tuple> findInItems(List<Item> items) {
-        return queryFactory
-                .select(review, user)
-                .from(review)
-                .join(user).on(review.user.eq(user))
-                .where(review.item.in(items))
-                .fetch();
-    }
-
-    @Override
-    public List<Review> findAllByUserId(Long userId) {
+    public List<Review> findByUserId(Long userId) {
         return queryFactory
                 .select(review)
                 .from(review)
@@ -52,20 +38,29 @@ public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
     }
 
     @Override
-    public Long countByUserId(Long userId) {
+    public Long countBySenderId(Long senderId) {
         return queryFactory
                 .select(review)
                 .from(review)
-                .where(review.user.id.eq(userId))
+                .where(review.user.id.eq(senderId))
                 .fetchCount();
     }
 
     @Override
-    public Long countInItems(List<Item> items) {
+    public List<Review> findByReveiverId(Long receiverId) {
         return queryFactory
                 .select(review)
                 .from(review)
-                .where(review.item.in(items))
+                .where(review.receiverId.eq(receiverId))
+                .fetch();
+    }
+
+    @Override
+    public Long countByReveiverId(Long receiverId) {
+        return queryFactory
+                .select(review)
+                .from(review)
+                .where(review.receiverId.eq(receiverId))
                 .fetchCount();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.Chat;
+import com.ducks.goodsduck.commons.model.entity.User;
 import com.ducks.goodsduck.commons.model.entity.UserChat;
 import com.querydsl.core.Tuple;
 import org.springframework.stereotype.Repository;
@@ -11,7 +12,9 @@ import java.util.List;
 public interface UserChatRepositoryCustom {
     List<UserChat> findAllByChatId(String chatId);
     List<Tuple> findChatAndItemByUserId(Long userId);
-    Tuple findSenderAndItemByChatIdAndUserId(String chatId, Long senderId);
+    User findSenderByChatIdAndUserId(String chatId, Long senderId);
     Chat findByUserIdAndItemId(Long userId, Long itemId);
     List<Tuple> findByItemIdExceptItemOwner(Long itemOwnerId, Long itemId);
+
+    UserChat findBySenderIdAndChatRoomId(Long senderId, String chatRoomId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepositoryCustomImpl.java
@@ -43,9 +43,9 @@ public class UserChatRepositoryCustomImpl implements UserChatRepositoryCustom {
     }
 
     @Override
-    public Tuple findSenderAndItemByChatIdAndUserId(String chatId, Long senderId) {
+    public User findSenderByChatIdAndUserId(String chatId, Long senderId) {
         return queryFactory
-                .select(userChat.user, userChat.item)
+                .select(userChat.user)
                 .from(userChat)
                 .where(userChat.chat.id.eq(chatId)
                         .and(userChat.user.id.eq(senderId)))
@@ -73,5 +73,15 @@ public class UserChatRepositoryCustomImpl implements UserChatRepositoryCustom {
                         .and(userChat.item.id.eq(itemId)))
                 .orderBy(userChat.id.desc())
                 .fetch();
+    }
+
+    @Override
+    public UserChat findBySenderIdAndChatRoomId(Long senderId, String chatRoomId) {
+        return queryFactory
+                .select(userChat)
+                .from(userChat)
+                .where(userChat.user.id.ne(senderId)
+                        .and(userChat.chat.id.eq(chatRoomId)))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
@@ -730,7 +730,7 @@ public class ItemService {
         Long countOfLikes = userItemRepository.countByUserId(userId);
 
         // 후기 Count
-        Long countOfReceivedReviews = reviewRepositoryCustom.countInItems(itemsByUserId);
+        Long countOfReceivedReviews = reviewRepositoryCustom.countByReveiverId(userId);
 
         // 가격제시 Count
         Long countOfReceievedPriceProposes = priceProposeRepositoryCustom.countSuggestedInItems(itemsByUserId);

--- a/src/main/java/com/ducks/goodsduck/commons/service/UserService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/UserService.java
@@ -1,6 +1,5 @@
 package com.ducks.goodsduck.commons.service;
 
-import com.ducks.goodsduck.commons.model.dto.ImageDto;
 import com.ducks.goodsduck.commons.model.dto.OtherUserPageDto;
 import com.ducks.goodsduck.commons.model.dto.oauth2.AuthorizationKakaoDto;
 import com.ducks.goodsduck.commons.model.dto.oauth2.AuthorizationNaverDto;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONObject;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.data.repository.NoRepositoryBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -298,11 +296,11 @@ public class UserService {
         }
 
         // 후기
-        List<Review> reviews = reviewRepositoryCustom.findAllByUserId(userId);
+        List<Review> reviews = reviewRepositoryCustom.findByUserId(userId);
 
         // 판매상품, 후기, 보증스탬프 개수
         Integer itemCount = items.size();
-        Long reviewCount = reviewRepositoryCustom.countByUserId(userId);
+        Long reviewCount = reviewRepositoryCustom.countBySenderId(userId);
 
         return new OtherUserPageDto(user, itemCount, reviewCount, showItems, reviews);
     }


### PR DESCRIPTION
### 변경된 점
- **DB 구조**
  - `Review`에 `Item` 연관관계가 들어있던걸 제거하였고, `receiverId` 컬럼으로 대체했습니다. (양방향 리뷰 기능을 위해)
- **Notification**
  - 기존에는 `Review`에 대한 타입이 존재하지 않아 추가하였습니다.
  - 리뷰의 경우는 `itemName` 속성이 빈 문자열("")로 들어갑니다.
  - `FirebaseMessage`에 `iconUri`(고정 URI), `messageUri`(구현 중) 속성을 추가하였습니다.
- **Review**
  - 데이터베이스 테이블에 변경이 있는 만큼, `Service`, `Repository` 코드에 다소 변경이 있었습니다.
  - 예시) 
    - 변경 전: 특정 게시물 작성자에 대한 리뷰를 불러오는 경우, `itemRepository_findByItemId` -> `itemRepository_findByUserId(item.userId)`에 해당하는 리뷰 조회
    - 변경 후: `itemRepository_findByItemId` -> `(item.userId==review.receiverId)`에 해당하는 리뷰 조회