### PR TITLE
[Timmy] SMS 인증 문자 전송 및 검증 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 	runtime 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtime 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+	// CoolSMS (authentication of SMS)
+	compile group: 'net.nurigo', name: 'javaSDK', version: '2.2'
+
+	compile('org.springframework.boot:spring-boot-starter-data-redis')
 	compile 'io.sentry:sentry-logback:1.7.30'
 	compile 'io.sentry:sentry-spring-boot-starter:1.7.30'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ChatController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ChatController.java
@@ -1,6 +1,5 @@
 package com.ducks.goodsduck.commons.controller;
 
-import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
 import com.ducks.goodsduck.commons.model.dto.notification.NotificationRequest;
 import com.ducks.goodsduck.commons.model.dto.chat.ChatAndItemDto;

--- a/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
@@ -32,6 +32,7 @@ import javax.persistence.NoResultException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.List;
+import java.util.Map;
 
 import static com.ducks.goodsduck.commons.model.dto.ApiResult.*;
 import static com.ducks.goodsduck.commons.model.enums.TradeStatus.valueOf;
@@ -50,6 +51,7 @@ public class UserController {
     private final UserChatService userChatService;
     private final JwtService jwtService;
     private final NotificationService notificationService;
+    private final SmsAuthenticationService smsAuthenticationService;
 
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
@@ -233,6 +235,23 @@ public class UserController {
     public ApiResult<List<NotificationResponse>> getNotificationsOfUser(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(notificationService.getNotificationsOfUserId(userId));
+    }
+
+    @NoCheckJwt
+    @PostMapping("/v1/authenticate")
+    @ApiOperation("SMS 인증 문자 전송")
+    public ApiResult sendAuthenticationSms(@RequestBody Map<String, String> smsAuthenticationInfo) throws Exception {
+        String phoneNumber = smsAuthenticationInfo.get("phoneNumber");
+        return OK(smsAuthenticationService.sendSmsOfAuthentication(phoneNumber));
+    }
+
+    @NoCheckJwt
+    @GetMapping("/v1/authenticate")
+    @ApiOperation("SMS 인증 번호에 대한 검증")
+    public ApiResult authenticateBySms(@RequestBody Map<String, String> smsAuthenticationInfo) {
+        String phoneNumber = smsAuthenticationInfo.get("phoneNumber");
+        String authenticationNumber = smsAuthenticationInfo.get("authenticationNumber");
+        return OK(smsAuthenticationService.authenticate(phoneNumber, authenticationNumber));
     }
 
     // TODO : 개발중 (경원)

--- a/src/main/java/com/ducks/goodsduck/commons/exception/GeneralExceptionHandler.java
+++ b/src/main/java/com/ducks/goodsduck/commons/exception/GeneralExceptionHandler.java
@@ -3,6 +3,7 @@ package com.ducks.goodsduck.commons.exception;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
 import com.sun.jdi.request.DuplicateRequestException;
 import lombok.extern.slf4j.Slf4j;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +50,12 @@ public class GeneralExceptionHandler {
     public ResponseEntity<ApiResult<?>> handleInvalidInputDataException(Exception e) {
         log.debug("Bad request exception occured: {}", e.getMessage(), e);
         return newResponse(e, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CoolsmsException.class)
+    public ResponseEntity<ApiResult<?>> handleCoolSmsException(CoolsmsException e) {
+        log.debug("Error occured during sending CoolSMS (code: {}): {} ", e.getCode(), e.getMessage(), e);
+        return newResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler({Exception.class, RuntimeException.class})

--- a/src/main/java/com/ducks/goodsduck/commons/repository/SmsAuthenticationRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/SmsAuthenticationRepository.java
@@ -1,0 +1,32 @@
+package com.ducks.goodsduck.commons.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class SmsAuthenticationRepository {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final String PREFIX = "sms:";
+    private final Long TIME_TO_LIMIT = 3 * 60L;
+
+    public void saveKeyAndValue(String phoneNumber, String authenticationNumber) {
+        stringRedisTemplate.opsForValue().set(PREFIX + phoneNumber, authenticationNumber, Duration.ofSeconds(TIME_TO_LIMIT));
+    }
+
+    public String getValueByPhoneNumber(String phoneNumber) {
+        return stringRedisTemplate.opsForValue().get(PREFIX + phoneNumber);
+    }
+
+    public void removeKeyAndValue(String phoneNumber) {
+        stringRedisTemplate.delete(PREFIX + phoneNumber);
+    }
+
+    public boolean hasKey(String phoneNumber) {
+        return stringRedisTemplate.hasKey(PREFIX + phoneNumber);
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/service/SmsAuthenticationService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/SmsAuthenticationService.java
@@ -1,0 +1,81 @@
+package com.ducks.goodsduck.commons.service;
+
+import com.ducks.goodsduck.commons.repository.SmsAuthenticationRepository;
+import com.ducks.goodsduck.commons.util.AwsSecretsManagerUtil;
+import com.ducks.goodsduck.commons.util.PropertyUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.java_sdk.api.Message;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+import org.json.JSONObject;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SmsAuthenticationService {
+
+    private final JSONObject jsonOfAwsSecrets = AwsSecretsManagerUtil.getSecret();
+    private String apiKey = jsonOfAwsSecrets.optString("coolsms.apikey", "");
+    private String apiSecret = jsonOfAwsSecrets.optString("coolsms.apisecret", "");
+    private String senderNumber = jsonOfAwsSecrets.optString("coolsms.sendernumber", "");
+
+    private final SmsAuthenticationRepository smsAuthenticationRepository;
+
+    public Boolean sendSmsOfAuthentication(String phoneNumber) throws Exception {
+        if (jsonOfAwsSecrets.isEmpty()) {
+            apiKey = PropertyUtil.getProperty("coolsms.apikey");
+            apiSecret = PropertyUtil.getProperty("coolsms.apisecret");
+            senderNumber = PropertyUtil.getProperty("coolsms.sendernumber");
+        }
+
+        Message coolsms = new Message(apiKey, apiSecret);
+        String authenticationNumber = generateAuthenticationNumber();
+
+        // 4 params(to, from, type, text) are mandatory. must be filled
+        HashMap<String, String> params = new HashMap<>();
+        params.put("to", phoneNumber);    // 수신전화번호
+        params.put("from", senderNumber);    // 발신전화번호. 테스트시에는 발신,수신 둘다 본인 번호로 하면 됨
+        params.put("type", "SMS");
+        params.put("text", "굿즈덕(GOODSDUCK) 인증번호는 \"" + authenticationNumber + "\" 입니다.");
+        params.put("app_version", "goodsduck app 1.0"); // application name and version
+
+        try {
+            org.json.simple.JSONObject sendedMessage = coolsms.send(params);
+            log.debug("Send message from CoolSMS: {}", sendedMessage.toString());
+            if (!sendedMessage.get("error_count").equals(0L)) {
+                return false;
+            }
+            smsAuthenticationRepository.saveKeyAndValue(phoneNumber, authenticationNumber);
+        } catch (CoolsmsException e) {
+            throw new CoolsmsException("Exception of CoolSMS: " + e.getMessage(), e.getCode());
+        } catch (Exception e) {
+            throw new Exception("Exception occurred in sending CoolSms: " + e.getMessage());
+        }
+        return true;
+    }
+
+    public Boolean authenticate(String phoneNumber, String authenticationNumber) {
+        if (smsAuthenticationRepository.hasKey(phoneNumber)) {
+            if (smsAuthenticationRepository.getValueByPhoneNumber(phoneNumber).equals(authenticationNumber)) {
+                smsAuthenticationRepository.removeKeyAndValue(phoneNumber);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public String generateAuthenticationNumber() {
+        Random random  = new Random();
+        String randomNumbers = "";
+        for(int i=0; i<6; i++) {
+            String randomNumber = Integer.toString(random.nextInt(10));
+            randomNumbers = randomNumbers.concat(randomNumber);
+        }
+        return randomNumbers;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -20,7 +20,7 @@
 
     <!-- Enable the Console and Sentry appenders, Console is provided as an example
  of a non-Sentry logger that is set to a different logging threshold -->
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="Console"/>
         <appender-ref ref="Sentry"/>
     </root>


### PR DESCRIPTION
### 추가된 API
- `POST` `/api/v1/authenticate`
  - RequestBody: phoneNumber(String) 
  - false/true 반환 (전송 성공 여부)
- `GET` `/api/v1/authenticate` : 핸드폰 번호에 대한 인증번호 검증
  - RequestBody: phoneNumber(String), authenticationNumber(String) 
  - false/true 반환 (검증 성공 여부)