### PR TITLE
[Timmy] 신고하기 기능 관련 APIs 구현

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ReportController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ReportController.java
@@ -2,9 +2,7 @@ package com.ducks.goodsduck.commons.controller;
 
 import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
-import com.ducks.goodsduck.commons.model.dto.report.CategoryReportDto;
-import com.ducks.goodsduck.commons.model.dto.report.ReportRequest;
-import com.ducks.goodsduck.commons.model.dto.report.ReportResponse;
+import com.ducks.goodsduck.commons.model.dto.report.*;
 import com.ducks.goodsduck.commons.service.ReportService;
 import com.ducks.goodsduck.commons.util.PropertyUtil;
 import io.swagger.annotations.Api;
@@ -26,11 +24,17 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @NoCheckJwt
     @PostMapping("/v1/category-report")
-    @ApiOperation("신고 유형 추가")
-    public ApiResult<CategoryReportDto> addCategoryReport(@RequestBody CategoryReportDto categoryReportDto) {
-        return OK(reportService.addCategoryReport(categoryReportDto));
+    @ApiOperation("(관리자) 신고 유형 추가")
+    public ApiResult<CategoryReportAddRequest> addCategoryReport(HttpServletRequest request, @RequestBody CategoryReportAddRequest categoryReportAddRequest) throws IllegalAccessException {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(reportService.addCategoryReport(userId, categoryReportAddRequest));
+    }
+
+    @GetMapping("/v1/category-report")
+    @ApiOperation("신고 유형 보기 및 신고할 대상 닉네임 확인")
+    public ApiResult<CategoryReportResponse> addCategoryReport(HttpServletRequest request, @RequestBody CategoryReportGetRequest categoryReportGetRequest) {
+        return OK(reportService.getCategoryReportWithUserNickName(categoryReportGetRequest));
     }
 
     @PostMapping("/v1/users/report")

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ReportController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ReportController.java
@@ -1,0 +1,49 @@
+package com.ducks.goodsduck.commons.controller;
+
+import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
+import com.ducks.goodsduck.commons.model.dto.ApiResult;
+import com.ducks.goodsduck.commons.model.dto.report.CategoryReportDto;
+import com.ducks.goodsduck.commons.model.dto.report.ReportRequest;
+import com.ducks.goodsduck.commons.model.dto.report.ReportResponse;
+import com.ducks.goodsduck.commons.service.ReportService;
+import com.ducks.goodsduck.commons.util.PropertyUtil;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.List;
+
+import static com.ducks.goodsduck.commons.model.dto.ApiResult.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Api(tags = "신고 관련 APIs")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @NoCheckJwt
+    @PostMapping("/v1/category-report")
+    @ApiOperation("신고 유형 추가")
+    public ApiResult<CategoryReportDto> addCategoryReport(@RequestBody CategoryReportDto categoryReportDto) {
+        return OK(reportService.addCategoryReport(categoryReportDto));
+    }
+
+    @PostMapping("/v1/users/report")
+    @ApiOperation("특정 사용자에 대한 신고 접수")
+    public ApiResult<ReportResponse> addReport(HttpServletRequest request, @RequestBody ReportRequest reportRequest) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(reportService.addReportFromUser(userId, reportRequest));
+    }
+
+    @GetMapping("/v1/users/{userId}/report")
+    @ApiOperation("(관리자) 특정 사용자가 받은 신고 목록 조회")
+    public ApiResult<List<ReportResponse>> addReport(HttpServletRequest request, @PathVariable("userId") Long receiverId) throws IllegalAccessException {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(reportService.getReportsForUser(userId, receiverId));
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportAddRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportAddRequest.java
@@ -6,15 +6,15 @@ import lombok.NoArgsConstructor;
 
 @Data
 @NoArgsConstructor
-public class CategoryReportDto {
+public class CategoryReportAddRequest {
 
     private String content;
 
-    public CategoryReportDto(String content) {
+    public CategoryReportAddRequest(String content) {
         this.content = content;
     }
 
-    public CategoryReportDto(CategoryReport categoryReport) {
+    public CategoryReportAddRequest(CategoryReport categoryReport) {
         this.content = categoryReport.getType();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportDto.java
@@ -1,0 +1,20 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import com.ducks.goodsduck.commons.model.entity.CategoryReport;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CategoryReportDto {
+
+    private String content;
+
+    public CategoryReportDto(String content) {
+        this.content = content;
+    }
+
+    public CategoryReportDto(CategoryReport categoryReport) {
+        this.content = categoryReport.getType();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportGetRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportGetRequest.java
@@ -1,0 +1,15 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CategoryReportGetRequest {
+
+    private String bcryptId;
+
+    public CategoryReportGetRequest(String bcryptId) {
+        this.bcryptId = bcryptId;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportGetResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportGetResponse.java
@@ -1,0 +1,23 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import com.ducks.goodsduck.commons.model.entity.CategoryReport;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CategoryReportGetResponse {
+
+    private Long id;
+    private String content;
+
+    public CategoryReportGetResponse(Long categoryReportId, String content) {
+        this.id = categoryReportId;
+        this.content = content;
+    }
+
+    public CategoryReportGetResponse(CategoryReport categoryReport) {
+        this.id = categoryReport.getId();
+        this.content = categoryReport.getType();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/CategoryReportResponse.java
@@ -1,0 +1,19 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class CategoryReportResponse {
+
+    private String receiverNickName;
+    private List<CategoryReportGetResponse> categoryReports;
+
+    public CategoryReportResponse(String receiverNickName, List<CategoryReportGetResponse> categoryReports) {
+        this.receiverNickName = receiverNickName;
+        this.categoryReports = categoryReports;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/ReportRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/ReportRequest.java
@@ -1,0 +1,24 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Data
+@NoArgsConstructor
+public class ReportRequest {
+
+    private String receiverBcryptId;
+    private Long categoryReportId;
+    private String content;
+    private LocalDateTime createdAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("Asia/Seoul"));;
+
+    public ReportRequest(String receiverBcryptId, Long categoryReportId, String content) {
+        this.receiverBcryptId = receiverBcryptId;
+        this.categoryReportId = categoryReportId;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/report/ReportResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/report/ReportResponse.java
@@ -1,0 +1,26 @@
+package com.ducks.goodsduck.commons.model.dto.report;
+
+import com.ducks.goodsduck.commons.model.entity.Report;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class ReportResponse {
+
+    private String receiverName;
+    private String categoryReportType;
+    private String content;
+    private LocalDateTime createdAt;
+    private Boolean isExist = false;
+
+    public ReportResponse(Report report) {
+        this.receiverName = report.getUser().getNickName();
+        this.categoryReportType = report.getCategoryReport().getType();
+        this.content = report.getContent();
+        this.createdAt = report.getCreatedAt();
+        this.isExist = true;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/CategoryReport.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/CategoryReport.java
@@ -1,0 +1,31 @@
+package com.ducks.goodsduck.commons.model.entity;
+
+import com.ducks.goodsduck.commons.model.dto.report.CategoryReportDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryReport {
+
+    @Id @Column(name = "CATEGORY_REPORT_ID")
+    @GeneratedValue
+    private Long id;
+
+    private String type;
+
+    public CategoryReport(String type) {
+        this.type = type;
+    }
+
+    public CategoryReport(CategoryReportDto categoryReportRequest) {
+        this.type = categoryReportRequest.getContent();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/CategoryReport.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/CategoryReport.java
@@ -1,6 +1,6 @@
 package com.ducks.goodsduck.commons.model.entity;
 
-import com.ducks.goodsduck.commons.model.dto.report.CategoryReportDto;
+import com.ducks.goodsduck.commons.model.dto.report.CategoryReportAddRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,7 +25,7 @@ public class CategoryReport {
         this.type = type;
     }
 
-    public CategoryReport(CategoryReportDto categoryReportRequest) {
+    public CategoryReport(CategoryReportAddRequest categoryReportRequest) {
         this.type = categoryReportRequest.getContent();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/Notification.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/Notification.java
@@ -8,7 +8,9 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 
 @Entity
 @Getter @Setter
@@ -60,7 +62,7 @@ public class Notification {
         this.itemId = userItem.getItem().getId();
         this.itemName = userItem.getItem().getName();
         this.type = NotificationType.USER_ITEM;
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("Asia/Seoul"));
     }
 
     public Notification(Review review, User receiver, NotificationType reviewType) {
@@ -80,7 +82,7 @@ public class Notification {
         this.senderImageUrl = senderImageUrl;
         this.itemName = itemName;
         this.type = type;
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("Asia/Seoul"));
     }
 
     public Notification(User user, String senderNickname, String senderImageUrl, Long itemId, String itemName, NotificationType type, Integer price) {
@@ -91,6 +93,6 @@ public class Notification {
         this.itemName = itemName;
         this.type = type;
         this.price = price;
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneId.of("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/Report.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/Report.java
@@ -1,0 +1,47 @@
+package com.ducks.goodsduck.commons.model.entity;
+
+import com.ducks.goodsduck.commons.model.dto.report.ReportRequest;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report {
+
+
+    @Id @Column(name = "REPORT_ID")
+    @GeneratedValue
+    private Long id;
+    private Long senderId;
+    private String content;
+    private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CATEGORY_REPORT_ID")
+    private CategoryReport categoryReport;
+
+    public Report(Long senderId, String content, LocalDateTime createdAt, User user, CategoryReport categoryReport) {
+        this.senderId = senderId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.user = user;
+        this.categoryReport = categoryReport;
+    }
+
+    public Report(ReportRequest reportRequest, CategoryReport categoryReport, User receiver, User user) {
+        this.senderId = receiver.getId();
+        this.content = reportRequest.getContent();
+        this.createdAt = reportRequest.getCreatedAt();
+        this.user = user;
+        this.categoryReport = categoryReport;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/CategoryReportRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/CategoryReportRepository.java
@@ -1,0 +1,7 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.entity.CategoryReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryReportRepository extends JpaRepository<CategoryReport, Long> {
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ReportRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ReportRepository.java
@@ -1,0 +1,12 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.entity.Report;
+import com.ducks.goodsduck.commons.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    Boolean existsByUserAndSenderId(Long userId, Long senderId);
+    List<Report> findByUser(User user);
+}

--- a/src/main/java/com/ducks/goodsduck/commons/service/ReportService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ReportService.java
@@ -1,0 +1,74 @@
+package com.ducks.goodsduck.commons.service;
+
+import com.ducks.goodsduck.commons.model.dto.report.CategoryReportDto;
+import com.ducks.goodsduck.commons.model.dto.report.ReportRequest;
+import com.ducks.goodsduck.commons.model.dto.report.ReportResponse;
+import com.ducks.goodsduck.commons.model.entity.CategoryReport;
+import com.ducks.goodsduck.commons.model.entity.Report;
+import com.ducks.goodsduck.commons.model.entity.User;
+import com.ducks.goodsduck.commons.repository.CategoryReportRepository;
+import com.ducks.goodsduck.commons.repository.ReportRepository;
+import com.ducks.goodsduck.commons.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.NoResultException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.ducks.goodsduck.commons.model.enums.UserRole.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReportService {
+
+    private final CategoryReportRepository categoryReportRepository;
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+
+    public CategoryReportDto addCategoryReport(CategoryReportDto categoryReportRequest) {
+        return new CategoryReportDto(categoryReportRepository.save(new CategoryReport(categoryReportRequest)));
+    }
+
+    public ReportResponse addReportFromUser(Long userId, ReportRequest reportRequest) {
+        User sender = userRepository.findById(userId).orElseThrow(() -> {
+            throw new NoResultException("User not founded.");
+        });
+
+        User receiver = userRepository.findByBcryptId(reportRequest.getReceiverBcryptId());
+
+        CategoryReport categoryReport = categoryReportRepository.findById(reportRequest.getCategoryReportId())
+                .orElseThrow(() -> {
+                    throw new NoResultException("CategoryReport not founded.");
+                });
+
+        if (reportRepository.existsByUserAndSenderId(sender.getId(), receiver.getId())) {
+            return new ReportResponse();
+        }
+
+        return new ReportResponse(
+                reportRepository.save(new Report(reportRequest, categoryReport, receiver, sender))
+        );
+    }
+
+    public List<ReportResponse> getReportsForUser(Long userId, Long receiverId) throws IllegalAccessException {
+        User loginUser = userRepository.findById(userId).orElseThrow(() -> {
+            throw new NoResultException("User not founded.");
+        });
+
+        User receiver = userRepository.findById(receiverId).orElseThrow(() -> {
+            throw new NoResultException("User not founded.");
+        });
+
+        if (!loginUser.getRole().equals(ADMIN)) {
+            throw new IllegalAccessException("관리자 권한이 필요합니다.");
+        }
+
+        return reportRepository.findByUser(receiver)
+                .stream()
+                .map(report -> new ReportResponse(report))
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
### 추가된 API
- `POST` `/api/v1/category-report` **(관리자용)**
  - 신고 유형을 클라이언트에서 추가할 수 있는 기능
  - 관리자용 ID로 생성한 `jwt`를 포함하면 사용 가능
- `GET` `/api/v1/category-report`
  - 신고 유형 목록과 신고하려는 대상 닉네임 조회
- `POST` `/api/v1/users/report`
  - 특정 사용자에 대한 신고 접수
  - 신고자는 `jwt`, 대상자는 `bcryptId`를 통해 신고
- `GET` `/api/v1/users/{userId}/report` **(관리자용)**
  - 특정 사용자가 받은 신고 목록을 조회할 수 있는 기능
  - 관리자용 ID로 생성한 `jwt`를 포함하면 사용 가능