### PR TITLE
[Timmy] 알림(include 채팅) 관련 API 리팩토링

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,9 +25,8 @@ fi
 echo "> $JAR_PATH 배포"
 
 JAR_NAME=$(ls -tr $JAR_PATH/*.jar | tail -n 1)
-TEST_PATH=$(ls $ENV_PATH/application-db.yml)
 
-echo "ENV PATH 인식 > $TEST_PATH"
+echo "ENV PATH 인식 > $ENV_PATH"
 
 nohup java -javaagent:/opt/newrelic/newrelic.jar \
         -jar -Dspring.config.location=classpath:/application.yml,$ENV_PATH/application-develop.yml,$ENV_PATH/application-s3.yml \

--- a/src/main/java/com/ducks/goodsduck/commons/config/AccessControlAllowFilter.java
+++ b/src/main/java/com/ducks/goodsduck/commons/config/AccessControlAllowFilter.java
@@ -16,10 +16,11 @@ public class AccessControlAllowFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) req;
         HttpServletResponse response = (HttpServletResponse) res;
 
-//         response.setHeader("Access-Control-Allow-Origin", "*");
-//         response.setHeader("Access-Control-Allow-Headers", "*");
-//         response.setHeader("Access-Control-Allow-Methods", "*");
-//         response.setHeader("Access-Control-Expose-Headers", "jwt");
+        // HINT: Nginx 단에서 CORS 관련 처리하도록 변경
+//        response.setHeader("Access-Control-Allow-Origin", "*");
+//        response.setHeader("Access-Control-Allow-Headers", "*");
+//        response.setHeader("Access-Control-Allow-Methods", "*");
+//        response.setHeader("Access-Control-Expose-Headers", "jwt");
 
         if(request.getMethod().equals(HttpMethod.OPTIONS.name())){
             response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ChatController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ChatController.java
@@ -2,17 +2,16 @@ package com.ducks.goodsduck.commons.controller;
 
 import com.drew.imaging.ImageProcessingException;
 import com.drew.metadata.MetadataException;
-import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
+import com.ducks.goodsduck.commons.model.dto.chat.*;
 import com.ducks.goodsduck.commons.model.dto.notification.NotificationRequest;
-import com.ducks.goodsduck.commons.model.dto.chat.ChatAndItemDto;
-import com.ducks.goodsduck.commons.model.dto.chat.ChatRequestDto;
-import com.ducks.goodsduck.commons.model.dto.chat.UserChatDto;
 import com.ducks.goodsduck.commons.model.enums.ImageType;
+import com.ducks.goodsduck.commons.service.ChatService;
 import com.ducks.goodsduck.commons.service.NotificationService;
 import com.ducks.goodsduck.commons.service.UserChatService;
 import com.ducks.goodsduck.commons.service.UserService;
 import com.ducks.goodsduck.commons.util.PropertyUtil;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -35,13 +34,14 @@ public class ChatController {
     private final UserChatService userChatService;
     private final UserService userService;
     private final NotificationService notificationService;
+    private final ChatService chatService;
 
     @ApiOperation("채팅방 생성 API by 즉시 판매/구매")
     @PostMapping("/v1/chat/items/{itemId}")
     public ApiResult<Boolean> createChatWithImmediateTrade(@PathVariable("itemId") Long itemId,
                                                            @RequestBody ChatRequestDto chatDto, HttpServletRequest request) {
 
-        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(userChatService.createWithImmediateTrade(chatDto.getChatId(), userId, itemId));
     }
 
@@ -50,7 +50,7 @@ public class ChatController {
     public ApiResult<Boolean> createChatWithPricePropose(@PathVariable("priceProposeId") Long priceProposeId,
                                                          @RequestBody ChatRequestDto chatDto, HttpServletRequest request) {
 
-        Long itemOwnerId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        var itemOwnerId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(userChatService.createWithPricePropose(chatDto.getChatId(), itemOwnerId, priceProposeId));
     }
 
@@ -63,31 +63,75 @@ public class ChatController {
     @ApiOperation("채팅방 이미지 업로드 API")
     @PostMapping("/v1/users/chat-image")
     public ApiResult<String> uploadChatImage(@RequestParam MultipartFile multipartFile, HttpServletRequest request) throws IOException, ImageProcessingException, MetadataException {
-        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(userService.uploadChatImage(multipartFile, ImageType.CHAT, userId));
     }
 
     @ApiOperation("채팅 전송 시 알림 요청 API")
     @PostMapping("/v1/chat/notification")
     public ApiResult<Boolean> sendNotification(HttpServletRequest request, @RequestBody NotificationRequest notificationRequest) throws IOException, IllegalAccessException {
-        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         notificationService.sendMessageOfChat(userId, notificationRequest);
         return OK(true);
     }
 
+    @ApiOperation("채팅 전송 시 알림 요청 API")
+    @PostMapping("/v2/chat/notification")
+    public ApiResult sendNotificationV2(HttpServletRequest request, @RequestBody ChatMessageRequest chatMessageRequest) throws IOException, IllegalAccessException, FirebaseMessagingException {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        notificationService.sendMessageOfChatV2(userId, chatMessageRequest);
+        return OK(true);
+    }
+
+    @ApiOperation("유저가 속한 채팅방 목록 조회 API")
+    @GetMapping("/v1/users/chats")
+    public ApiResult getChatRooms(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        chatService.findChatRooms(userId);
+        return OK(true);
+    }
+
+    @ApiOperation("유저가 속한 채팅방 목록 조회 API")
+    @GetMapping("/v2/users/chats")
+    public ApiResult<List<ChatRoomResponse>> getChatRoomsV2(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(chatService.findChatRoomsV2(userId));
+    }
+
+    @ApiOperation("채팅방 접속 시 채팅 읽음 처리 API")
+    @DeleteMapping("/v1/users/chats/{chatRoomId}")
+    public ApiResult readChatMessages(HttpServletRequest request, @PathVariable("chatRoomId") String chatRoomId) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        chatService.readChatMessages(userId, chatRoomId);
+        return OK(true);
+    }
+
+    @ApiOperation("안 읽은 채팅 메시지 여부 조회 API")
+    @GetMapping("/v1/users/chats/noty")
+    public ApiResult checkUnreadChat(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(chatService.checkUnreadChat(userId));
+    }
+
+
     @ApiOperation("(삭제예정) 채팅방 ID를 통한 User 정보 획득 API")
     @GetMapping("/v1/chat/{chatId}")
     public ApiResult<UserChatDto> getChatInfo(@PathVariable("chatId") String chatId, HttpServletRequest request) throws IllegalAccessException {
-
-        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(userChatService.getChatInfo(chatId, userId));
     }
 
     @ApiOperation("(삭제예정) 유저가 속해있는 채팅방 정보 획득 API")
     @GetMapping("/v1/chat")
-    public ApiResult<List<ChatAndItemDto>> getChatInfoOfUser(HttpServletRequest request) {
+    public ApiResult<List<ChatRoomDto>> getChatInfoOfUser(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(userChatService.getChatRooms(userId));
+    }
 
-        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
-        return OK(userChatService.getChatInfoOfUser(userId));
+    @ApiOperation("유저가 속해있는 채팅방 정보 획득 API")
+    @GetMapping("/v2/chat")
+    public ApiResult<List<ChatRoomDto>> getChatInfoOfUserV2(HttpServletRequest request) {
+        var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(userChatService.getChatRoomsV2(userId));
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/controller/JwtController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/JwtController.java
@@ -24,9 +24,9 @@ public class JwtController {
 
     // 개발 테스트용 (토큰 발급)
     @NoCheckJwt
-    @GetMapping("/gen/token")
-    public ApiResult<Map<String, Object>> genToken(@RequestParam(value="subject") String subject) {
-        String token = jwtService.createJwt(subject, 1L);
+    @GetMapping("/gen/token/{itemId}")
+    public ApiResult<Map<String, Object>> genToken(@RequestParam(value="subject") String subject, @PathVariable("itemId") Long itemId) {
+        String token = jwtService.createJwt(subject, itemId);
         Map<String, Object> map = new HashMap<>();
         map.put("result", token);
         return OK(map);

--- a/src/main/java/com/ducks/goodsduck/commons/controller/PriceProposeController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/PriceProposeController.java
@@ -53,7 +53,9 @@ public class PriceProposeController {
                     throw new NoResultException("User not founded.");
                 });
 
-        notificationService.sendMessage(new Notification(user, priceProposeResponse));
+        // TODO: 프론트 연동 테스트 후 문제 없을 시 sendMessageV2로 변경
+//        notificationService.sendMessage(new Notification(user, priceProposeResponse));
+        notificationService.sendMessageV2(new Notification(user, priceProposeResponse));
 
         return OK(priceProposeResponse);
     }

--- a/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ReviewController.java
@@ -14,6 +14,7 @@ import com.ducks.goodsduck.commons.repository.UserRepository;
 import com.ducks.goodsduck.commons.service.NotificationService;
 import com.ducks.goodsduck.commons.service.ReviewService;
 import com.ducks.goodsduck.commons.util.PropertyUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +54,7 @@ public class ReviewController {
     @PostMapping("/v1/users/reviews")
     @ApiOperation("채팅방 ID를 통해 특정 유저에 대한 리뷰 남기기")
     public ApiResult<Boolean> sendReview(HttpServletRequest request,
-                                         @RequestBody ReviewRequest reviewRequest) throws IllegalAccessException {
+                                         @RequestBody ReviewRequest reviewRequest) throws IllegalAccessException, JsonProcessingException {
         var userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         Review savedReview = reviewService.saveReview(userId, reviewRequest)
                 .orElseThrow(() -> {
@@ -63,7 +64,9 @@ public class ReviewController {
         User receiver = userRepository.findById(savedReview.getReceiverId()).orElseThrow(() -> {
             throw new NoResultException("User not founded.");
         });
-        notificationService.sendMessage(new Notification(savedReview, receiver, reviewRequest.getReviewType()));
+        // TODO: 프론트 연동 테스트 후 문제 없을 시 sendMessageV2로 변경
+//        notificationService.sendMessage(new Notification(savedReview, receiver, reviewRequest.getReviewType()));
+        notificationService.sendMessageV2(new Notification(savedReview, receiver, reviewRequest.getReviewType()));
         return OK(true);
     }
 

--- a/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
@@ -16,6 +16,7 @@ import com.ducks.goodsduck.commons.model.dto.user.*;
 import com.ducks.goodsduck.commons.model.entity.Item;
 import com.ducks.goodsduck.commons.model.enums.SocialType;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
+import com.ducks.goodsduck.commons.model.dto.notification.NotificationRedisResponse;
 import com.ducks.goodsduck.commons.repository.item.ItemRepository;
 import com.ducks.goodsduck.commons.repository.UserRepository;
 import com.ducks.goodsduck.commons.service.*;
@@ -218,6 +219,13 @@ public class UserController {
     public ApiResult<List<NotificationResponse>> getNotificationsOfUser(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(notificationService.getNotificationsOfUserId(userId));
+    }
+
+    @GetMapping("/v2/users/notifications")
+    @ApiOperation("사용자가 받은 알림 목록 조회 API V2")
+    public ApiResult<List<NotificationRedisResponse>> getNotificationsOfUserV2(HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(notificationService.getNotificationsOfUserIdV2(userId));
     }
 
     @NoCheckJwt

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatMessageRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatMessageRequest.java
@@ -1,0 +1,20 @@
+package com.ducks.goodsduck.commons.model.dto.chat;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ChatMessageRequest {
+
+    private String chatMessageId;
+    private String chatRoomId;
+    private Long senderId;
+    private String content;
+
+    public ChatMessageRequest(String chatRoomId, Long senderId, String content) {
+        this.chatRoomId = chatRoomId;
+        this.senderId = senderId;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatResponse.java
@@ -1,0 +1,26 @@
+package com.ducks.goodsduck.commons.model.dto.chat;
+
+import com.ducks.goodsduck.commons.model.redis.ChatRedis;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+public class ChatResponse {
+
+    private String id;
+    private String chatRoomId;
+    private String content;
+    private String senderNickName;
+    private LocalDateTime createdAt;
+
+    public ChatResponse(ChatRedis chatRedis) {
+        this.id = chatRedis.getId();
+        this.chatRoomId = chatRedis.getChatRoomId();
+        this.content = chatRedis.getContent();
+        this.senderNickName = chatRedis.getSenderNickName();
+        this.createdAt = chatRedis.getCreatedAt();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatRoomDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatRoomDto.java
@@ -6,13 +6,20 @@ import com.ducks.goodsduck.commons.model.entity.Item;
 import lombok.Data;
 
 @Data
-public class ChatAndItemDto {
+public class ChatRoomDto {
 
     private String chatId;
     private ItemSummaryDto itemSimpleDto;
+    private String senderNickName;
 
-    public ChatAndItemDto(Chat chat, Item item) {
+    public ChatRoomDto(Chat chat, Item item) {
         this.chatId = chat.getId();
         this.itemSimpleDto = new ItemSummaryDto(item);
+    }
+
+    public ChatRoomDto(Chat chat, Item item, String senderNickName) {
+        this.chatId = chat.getId();
+        this.itemSimpleDto = new ItemSummaryDto(item);
+        this.senderNickName = senderNickName;
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatRoomResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/chat/ChatRoomResponse.java
@@ -1,0 +1,23 @@
+package com.ducks.goodsduck.commons.model.dto.chat;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ChatRoomResponse {
+
+    private String chatRoomId;
+    private Integer size;
+    private ChatResponse lastMessage;
+
+    public ChatRoomResponse(String chatRoomId, Integer size, ChatResponse lastMessage) {
+        this.chatRoomId = chatRoomId;
+        this.size = size;
+        this.lastMessage = lastMessage;
+    }
+
+    public ChatRoomResponse(String chatRoomId) {
+        this.chatRoomId = chatRoomId;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/notification/NotificationRedisResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/notification/NotificationRedisResponse.java
@@ -1,0 +1,46 @@
+package com.ducks.goodsduck.commons.model.dto.notification;
+
+import com.ducks.goodsduck.commons.model.enums.NotificationType;
+import com.ducks.goodsduck.commons.model.redis.NotificationRedis;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationRedisResponse implements Serializable {
+
+    private String id;
+    private NotificationType type;
+    private Long reviewId;
+    private Long priceProposeId;
+    private Integer priceProposePrice;
+    private String senderNickName;
+    private Long itemId;
+    private String itemName;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiredAt;
+    private Boolean isRead;
+
+    public void read() {
+        this.isRead = true;
+    }
+
+    public NotificationRedisResponse(NotificationRedis notificationRedis) {
+        this.id = notificationRedis.getId();
+        this.type = notificationRedis.getType();
+        this.reviewId = notificationRedis.getReviewId();
+        this.priceProposeId = notificationRedis.getPriceProposeId();
+        this.priceProposePrice = notificationRedis.getPriceProposePrice();
+        this.senderNickName = notificationRedis.getSenderNickName();
+        this.itemId = notificationRedis.getItemId();
+        this.itemName = notificationRedis.getItemName();
+        this.createdAt =  notificationRedis.getCreatedAt();
+        this.expiredAt = notificationRedis.getExpiredAt();
+        this.isRead = notificationRedis.getIsRead();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/redis/ChatRedis.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/redis/ChatRedis.java
@@ -1,0 +1,43 @@
+package com.ducks.goodsduck.commons.model.redis;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRedis {
+    @Id
+    private String id;
+    private String chatRoomId;
+    private String content;
+    private String senderNickName;
+    private Boolean isRead;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime createdAt;
+
+    public void read() {
+        this.isRead = true;
+    }
+
+    public ChatRedis(String chatMessageId, String chatRoomId, String content, String senderNickName) {
+        this.id = chatMessageId;
+        this.chatRoomId = chatRoomId;
+        this.content = content;
+        this.senderNickName = senderNickName;
+        this.createdAt = LocalDateTime.now();
+        this.isRead = false;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/redis/NotificationRedis.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/redis/NotificationRedis.java
@@ -1,0 +1,71 @@
+package com.ducks.goodsduck.commons.model.redis;
+
+import com.ducks.goodsduck.commons.model.enums.NotificationType;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Id;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static com.ducks.goodsduck.commons.model.enums.NotificationType.PRICE_PROPOSE;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationRedis implements Serializable {
+
+    @Id
+    private String id;
+    private NotificationType type;
+    private Long reviewId;
+    private Long priceProposeId;
+    private Integer priceProposePrice;
+    private String senderNickName;
+    private Long itemId;
+    private String itemName;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime createdAt;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime expiredAt;
+    private Boolean isRead;
+
+    public void read() {
+        this.isRead = true;
+    }
+
+    // HINT: REVIEW
+    public NotificationRedis(NotificationType type, Long reviewId, String senderNickName) {
+        this.id = UUID.randomUUID().toString();
+        this.type = type;
+        this.reviewId = reviewId;
+        this.senderNickName = senderNickName;
+        this.createdAt = LocalDateTime.now();
+        this.expiredAt = createdAt.plusWeeks(2L);
+        this.isRead = false;
+    }
+
+    // HINT: PricePropose
+    public NotificationRedis(Long priceProposeId, Integer priceProposePrice, Long itemId, String itemName, String senderNickName) {
+        this.id = UUID.randomUUID().toString();
+        this.type = PRICE_PROPOSE;
+        this.senderNickName = senderNickName;
+        this.priceProposeId = priceProposeId;
+        this.priceProposePrice = priceProposePrice;
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.createdAt = LocalDateTime.now();
+        this.expiredAt = createdAt.plusWeeks(2L);
+        this.isRead = false;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ChatRedisTemplate.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ChatRedisTemplate.java
@@ -1,0 +1,107 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.dto.chat.ChatResponse;
+import com.ducks.goodsduck.commons.model.redis.ChatRedis;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.*;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+@Slf4j
+public class ChatRedisTemplate {
+
+    private final RedisTemplate redisTemplate;
+    private final ListOperations<String, ChatRedis> redisDtoListOperations;
+
+    private final String PREFIX_OF_USER = "user:";
+    private final String PREFIX_OF_CHAT = ":chatRoom:";
+
+    public ChatRedisTemplate(RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(ChatRedis.class));
+        this.redisDtoListOperations = redisTemplate.opsForList();
+    }
+
+    public void saveChatKeyAndValueByUserId(Long userId, ChatRedis chatRedis) {
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_CHAT + chatRedis.getChatRoomId();
+        redisTemplate.opsForList().leftPush(key, chatRedis);
+    }
+
+    // Chat
+    public List<ChatResponse> findAndPopExceptFirstMessageByUserId(Long userId) {
+
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_CHAT;
+        RedisConnection redisConnection = redisTemplate.getConnectionFactory().getConnection();
+        ScanOptions options = ScanOptions.scanOptions().match(key).count(5).build();
+
+        Cursor<byte[]> c = redisConnection.scan(options);
+        while (c.hasNext()) {
+            log.info(new String(c.next()));
+        }
+
+        // TODO: 전체 채팅방을 불러오도록 구현해야 함. (단일 채팅방 X)
+
+        List<ChatRedis> chatRedisList = redisDtoListOperations.range(key, 0, -1);
+        List<ChatResponse> chatResponses = chatRedisList
+                .stream()
+                .map(chatRedis -> new ChatResponse(chatRedis))
+                .collect(Collectors.toList());
+
+        int size = chatResponses.size();
+        while ( size > 1 ) {
+            redisDtoListOperations.rightPop(key);
+            size--;
+        }
+
+        return chatResponses;
+    }
+
+    /**
+     * 특정 key 값에 해당하는 리스트 가져오기
+     * @param key ("user:{userId}:chatRoom:{chatRoomID}")
+     * @return 해당 유저가 받은 ChatMessage가 담긴 리스트
+     */
+    public List<ChatRedis> getMessages(String key) {
+
+        return redisDtoListOperations.range(key, 0, -1);
+    }
+
+    /**
+     * userId에 해당하는 chatRoom과 관련된 key 값들 가져오기
+     * @param userId
+     * @return key 값이 담긴 리스트 ex. ["user:3:chatRoom:-Mwi3mf2l-wkffm3", "user:3:chatRoom:-M1b3gfrl-vnm4dr", ..]
+     */
+    public List<String> scanKeysByUserId(Long userId) {
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_CHAT;
+        RedisConnection redisConnection = redisTemplate.getConnectionFactory().getConnection();
+        ScanOptions options = ScanOptions.scanOptions().match(key + "*").count(5).build();
+
+        List<String> keys = new ArrayList<>();
+        Cursor<byte[]> c = redisConnection.scan(options);
+        while (c.hasNext()) {
+            String nextKey = new String(c.next());
+            log.info("List of key: " + nextKey);
+            keys.add(nextKey);
+        }
+        return keys;
+    }
+
+    /**
+     * userId, chatRoomId에 해당하는(key 값 예시: "user:3:chatRoom:-Mwi3mf2l-wkffm3") 전체 삭제(리스트)
+     * @param userId
+     * @param chatRoomId
+     */
+    public void removeChatMessages(Long userId, String chatRoomId) {
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_CHAT + chatRoomId;
+        redisTemplate.delete(key);
+    }
+
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ImageRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ImageRepositoryCustom.java
@@ -1,6 +1,8 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.Image;
+import com.ducks.goodsduck.commons.model.entity.ItemImage;
+import com.ducks.goodsduck.commons.model.enums.ImageType;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,6 @@ import java.util.List;
 public interface ImageRepositoryCustom {
 
     List<Image> findByImageUrls(List<String> imageUrls);
+    List<Image> findItemImages();
+//    List<Image> findByImageType(ImageType imageType);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/ImageRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/ImageRepositoryCustomImpl.java
@@ -1,13 +1,17 @@
 package com.ducks.goodsduck.commons.repository;
 
 import com.ducks.goodsduck.commons.model.entity.Image;
+import com.ducks.goodsduck.commons.model.entity.ItemImage;
 import com.ducks.goodsduck.commons.model.entity.QImage;
+import com.ducks.goodsduck.commons.model.entity.QItemImage;
+import com.ducks.goodsduck.commons.model.enums.ImageType;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Repository
 public class ImageRepositoryCustomImpl implements ImageRepositoryCustom {
@@ -15,6 +19,7 @@ public class ImageRepositoryCustomImpl implements ImageRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     private QImage image = QImage.image;
+    private QItemImage itemImage = QItemImage.itemImage;
 
     public ImageRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
@@ -33,6 +38,15 @@ public class ImageRepositoryCustomImpl implements ImageRepositoryCustom {
                 .select(image)
                 .from(image)
                 .where(builder)
+                .fetch();
+    }
+
+    @Override
+    public List<Image> findItemImages() {
+        return queryFactory
+                .select(image)
+                .from(image)
+                .leftJoin(itemImage).on(image.id.eq(itemImage.id))
                 .fetch();
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/NotificationRedisTemplate.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/NotificationRedisTemplate.java
@@ -1,0 +1,59 @@
+package com.ducks.goodsduck.commons.repository;
+
+import com.ducks.goodsduck.commons.model.redis.NotificationRedis;
+import com.ducks.goodsduck.commons.model.dto.notification.NotificationRedisResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Repository
+public class NotificationRedisTemplate {
+
+    private final RedisTemplate redisTemplate;
+    private final ListOperations<String, NotificationRedis> redisDtoListOperations;
+
+    private final String PREFIX_OF_USER = "user:";
+    private final String PREFIX_OF_NOTIFICATION = ":notificaition";
+
+    public NotificationRedisTemplate(RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer(NotificationRedis.class));
+        this.redisDtoListOperations = redisTemplate.opsForList();
+    }
+
+    public void saveNotificationKeyAndValueByUserId(Long userId, NotificationRedis notificationRedis) throws JsonProcessingException {
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_NOTIFICATION;
+        redisTemplate.opsForList().leftPush(key, notificationRedis);
+    }
+
+    public List<NotificationRedisResponse> findByUserId(Long userId) {
+        String key = PREFIX_OF_USER + userId + PREFIX_OF_NOTIFICATION;
+        List<NotificationRedis> notificationRedisList = redisDtoListOperations.range(key, 0, -1);
+        List<NotificationRedisResponse> notificationRedisResponses = notificationRedisList
+                .stream()
+                .map(notificationRedis -> new NotificationRedisResponse(notificationRedis))
+                .collect(Collectors.toList());
+
+        int size = notificationRedisList.size()-1;
+        while ( size >= 0 && notificationRedisList.get(size).getExpiredAt().isBefore(LocalDateTime.now())) {
+            redisDtoListOperations.rightPop(key);
+            size--;
+        }
+
+        NotificationRedis notificationRedis;
+        for (int i = 0; i <= size; i++) {
+            notificationRedis = notificationRedisList.get(i);
+            if (notificationRedis.getIsRead()) break;
+            notificationRedis.read();
+            redisDtoListOperations.set(key, i, notificationRedis);
+        }
+
+        return notificationRedisResponses;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/SmsAuthenticationRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/SmsAuthenticationRepository.java
@@ -1,32 +1,35 @@
 package com.ducks.goodsduck.commons.repository;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 
 @Repository
-@RequiredArgsConstructor
 public class SmsAuthenticationRepository {
 
     private final StringRedisTemplate stringRedisTemplate;
-    private final String PREFIX = "sms:";
-    private final Long TIME_TO_LIMIT = 3 * 60L;
 
-    public void saveKeyAndValue(String phoneNumber, String authenticationNumber) {
-        stringRedisTemplate.opsForValue().set(PREFIX + phoneNumber, authenticationNumber, Duration.ofSeconds(TIME_TO_LIMIT));
+    private final String PREFIX_OF_SMS = "sms:";
+    private final Long TTL_OF_SMS = 3 * 60L;
+
+    public SmsAuthenticationRepository(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    public void saveKeyAndValueOfSMS(String phoneNumber, String authenticationNumber) {
+        stringRedisTemplate.opsForValue().set(PREFIX_OF_SMS + phoneNumber, authenticationNumber, Duration.ofSeconds(TTL_OF_SMS));
     }
 
     public String getValueByPhoneNumber(String phoneNumber) {
-        return stringRedisTemplate.opsForValue().get(PREFIX + phoneNumber);
+        return stringRedisTemplate.opsForValue().get(PREFIX_OF_SMS + phoneNumber);
     }
 
-    public void removeKeyAndValue(String phoneNumber) {
-        stringRedisTemplate.delete(PREFIX + phoneNumber);
+    public void removeKeyAndValueOfSMS(String phoneNumber) {
+        stringRedisTemplate.delete(PREFIX_OF_SMS + phoneNumber);
     }
 
     public boolean hasKey(String phoneNumber) {
-        return stringRedisTemplate.hasKey(PREFIX + phoneNumber);
+        return stringRedisTemplate.hasKey(PREFIX_OF_SMS + phoneNumber);
     }
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/UserChatRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 @Repository
 public interface UserChatRepository extends JpaRepository<UserChat, Long> {
+    List<UserChat> findByUserId(Long userId);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/service/ChatService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ChatService.java
@@ -1,0 +1,66 @@
+package com.ducks.goodsduck.commons.service;
+
+import com.ducks.goodsduck.commons.model.dto.chat.ChatResponse;
+import com.ducks.goodsduck.commons.model.dto.chat.ChatRoomResponse;
+import com.ducks.goodsduck.commons.model.redis.ChatRedis;
+import com.ducks.goodsduck.commons.repository.ChatFirebaseRepository;
+import com.ducks.goodsduck.commons.repository.ChatRedisTemplate;
+import com.ducks.goodsduck.commons.repository.ChatRepository;
+import com.ducks.goodsduck.commons.repository.UserChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatFirebaseRepository chatFirebaseRepository;
+    private final ChatRepository chatRepository;
+    private final UserChatRepository userChatRepository;
+    private final ChatRedisTemplate chatRedisTemplate;
+
+    public void findChatRooms(Long userId) {
+        userChatRepository.findByUserId(userId);
+    }
+
+    public List<ChatRoomResponse> findChatRoomsV2(Long userId) {
+
+        List<String> keys = chatRedisTemplate.scanKeysByUserId(userId);
+        List<ChatRoomResponse> chatRoomResponses = new ArrayList<>();
+
+        ChatRoomResponse chatRoomResponse;
+        ChatResponse chatResponse;
+        ChatRedis chatRedis;
+        List<ChatRedis> messages;
+        String chatRoomId;
+        int size;
+        for (String key : keys) {
+            messages = chatRedisTemplate.getMessages(key);
+            chatRoomId = key.split(":")[3];
+            size = messages.size();
+            if (size == 0) {
+                chatRoomResponse = new ChatRoomResponse(chatRoomId);
+            } else {
+                chatRedis = messages.get(0);
+                chatResponse = new ChatResponse(chatRedis);
+                chatRoomResponse = new ChatRoomResponse(chatRoomId, size, chatResponse);
+            }
+
+            chatRoomResponses.add(chatRoomResponse);
+        }
+
+        return chatRoomResponses;
+    }
+
+    public Boolean checkUnreadChat(Long userId) {
+        return !chatRedisTemplate.scanKeysByUserId(userId).isEmpty();
+    }
+
+    public void readChatMessages(Long userId, String chatRoomId) {
+        chatRedisTemplate.removeChatMessages(userId, chatRoomId);
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/service/NotificationService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/NotificationService.java
@@ -1,11 +1,18 @@
 package com.ducks.goodsduck.commons.service;
 
+import com.ducks.goodsduck.commons.model.dto.chat.ChatMessageRequest;
 import com.ducks.goodsduck.commons.model.dto.notification.NotificationBadgeResponse;
 import com.ducks.goodsduck.commons.model.dto.notification.NotificationRequest;
 import com.ducks.goodsduck.commons.model.dto.notification.NotificationResponse;
 import com.ducks.goodsduck.commons.model.entity.Notification;
+import com.ducks.goodsduck.commons.model.entity.User;
 import com.ducks.goodsduck.commons.model.entity.UserChat;
+import com.ducks.goodsduck.commons.model.enums.NotificationType;
+import com.ducks.goodsduck.commons.model.redis.ChatRedis;
+import com.ducks.goodsduck.commons.model.redis.NotificationRedis;
+import com.ducks.goodsduck.commons.model.dto.notification.NotificationRedisResponse;
 import com.ducks.goodsduck.commons.repository.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,7 +23,7 @@ import java.io.*;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static com.ducks.goodsduck.commons.model.enums.NotificationType.CHAT;
+import static com.ducks.goodsduck.commons.model.enums.NotificationType.*;
 import static com.google.firebase.messaging.Notification.*;
 
 @Service
@@ -29,13 +36,23 @@ public class NotificationService {
     private final NotificationRepositoryCustomImpl notificationRepositoryCustomImpl;
     private final UserChatRepositoryCustom userChatRepositoryCustom;
     private final UserRepository userRepository;
+    private final NotificationRedisTemplate notificationRedisTemplate;
+    private final ChatRedisTemplate chatRedisTemplate;
 
-    public NotificationService(DeviceRepositoryCustomImpl userDeviceRepositoryCustom, NotificationRepository notificationRepository, NotificationRepositoryCustomImpl notificationRepositoryCustomImpl, UserChatRepositoryCustomImpl userChatRepositoryCustom, UserRepository userRepository) {
+    public NotificationService(DeviceRepositoryCustomImpl userDeviceRepositoryCustom,
+                               NotificationRepository notificationRepository,
+                               NotificationRepositoryCustomImpl notificationRepositoryCustomImpl,
+                               UserChatRepositoryCustomImpl userChatRepositoryCustom,
+                               UserRepository userRepository,
+                               NotificationRedisTemplate notificationRedisTemplate,
+                               ChatRedisTemplate chatRedisTemplate) {
         this.deviceRepositoryCustom = userDeviceRepositoryCustom;
         this.notificationRepository = notificationRepository;
         this.notificationRepositoryCustomImpl = notificationRepositoryCustomImpl;
         this.userChatRepositoryCustom = userChatRepositoryCustom;
         this.userRepository = userRepository;
+        this.notificationRedisTemplate = notificationRedisTemplate;
+        this.chatRedisTemplate = chatRedisTemplate;
     }
 
     public void sendMessage(Notification notification) {
@@ -55,7 +72,7 @@ public class NotificationService {
             // HINT: 알림 Message 구성
             MulticastMessage message = getMulticastMessage(notification, registrationTokens)
                     .build();
-            log.debug("firebase message is : " + message);
+            log.debug("firebase message is : \n" + message.toString());
 
             // HINT: 파이어베이스에 Cloud Messaging 요청
             requestCloudMessagingToFirebase(registrationTokens, message);
@@ -66,6 +83,52 @@ public class NotificationService {
         } catch (Exception e) {
             log.debug(e.getMessage(), e);
 //            throw new IOException(e.getMessage()); // 알림은 예외 발생 시 기능 처리에 영향을 주지 않도록 한다.
+        }
+    }
+
+    public void sendMessageV2(Notification notification) throws JsonProcessingException {
+
+        // 알림 데이터 저장 (DB)
+        NotificationType notificationType = notification.getType();
+        NotificationRedis notificationRedis;
+
+        if (notificationType.equals(REVIEW) || notificationType.equals(REVIEW_FIRST)) {
+            notificationRedis = new NotificationRedis(notificationType, notification.getReviewId(), notification.getSenderNickName());
+
+        } else if (notificationType.equals(PRICE_PROPOSE)) {
+            notificationRedis = new NotificationRedis(notification.getPriceProposeId(),
+                    notification.getPrice(),
+                    notification.getItemId(),
+                    notification.getItemName(),
+                    notification.getSenderNickName());
+        } else {
+            return;
+        }
+
+        // TODO: Redis에 알림 데이터 담기
+        notificationRedisTemplate.saveNotificationKeyAndValueByUserId(notification.getUser().getId(), notificationRedis);
+
+        try {
+            // 사용자가 등록한 Device(FCM 토큰) 조회
+            List<String> registrationTokens = deviceRepositoryCustom.getRegistrationTokensByUserId(notification.getUser().getId());
+
+            if (registrationTokens.isEmpty()) {
+                log.debug("Device for notification not founded.");
+                return;
+            }
+
+            // HINT: 알림 Message 구성
+            MulticastMessage message = getMulticastMessage(notification, registrationTokens)
+                    .build();
+            log.debug("firebase message is : " + message);
+
+            // HINT: 파이어베이스에 Cloud Messaging 요청
+            requestCloudMessagingToFirebase(registrationTokens, message);
+
+        } catch (FirebaseMessagingException e) {
+            log.debug(e.getMessage(), e); // 알림은 예외 발생 시 기능 처리에 영향을 주지 않도록 한다.
+        } catch (Exception e) {
+            log.debug(e.getMessage(), e); // 알림은 예외 발생 시 기능 처리에 영향을 주지 않도록 한다.
         }
     }
 
@@ -177,6 +240,11 @@ public class NotificationService {
                     return notificationResponse;
                 })
                 .collect(Collectors.toList());
+    }
+
+    public List<NotificationRedisResponse> getNotificationsOfUserIdV2(Long userId) {
+
+        return notificationRedisTemplate.findByUserId(userId);
     }
 
     /** 읽지 않은 알림 유무 체크 */

--- a/src/main/java/com/ducks/goodsduck/commons/service/SmsAuthenticationService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/SmsAuthenticationService.java
@@ -49,7 +49,7 @@ public class SmsAuthenticationService {
             if (!sendedMessage.get("error_count").equals(0L)) {
                 return false;
             }
-            smsAuthenticationRepository.saveKeyAndValue(phoneNumber, authenticationNumber);
+            smsAuthenticationRepository.saveKeyAndValueOfSMS(phoneNumber, authenticationNumber);
         } catch (CoolsmsException e) {
             throw new CoolsmsException("Exception of CoolSMS: " + e.getMessage(), e.getCode());
         } catch (Exception e) {
@@ -61,7 +61,7 @@ public class SmsAuthenticationService {
     public Boolean authenticate(String phoneNumber, String authenticationNumber) {
         if (smsAuthenticationRepository.hasKey(phoneNumber)) {
             if (smsAuthenticationRepository.getValueByPhoneNumber(phoneNumber).equals(authenticationNumber)) {
-                smsAuthenticationRepository.removeKeyAndValue(phoneNumber);
+                smsAuthenticationRepository.removeKeyAndValueOfSMS(phoneNumber);
                 return true;
             }
         }

--- a/src/main/java/com/ducks/goodsduck/commons/service/UserChatService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/UserChatService.java
@@ -1,7 +1,7 @@
 package com.ducks.goodsduck.commons.service;
 
 import com.ducks.goodsduck.commons.model.dto.review.TradeCompleteReponse;
-import com.ducks.goodsduck.commons.model.dto.chat.ChatAndItemDto;
+import com.ducks.goodsduck.commons.model.dto.chat.ChatRoomDto;
 import com.ducks.goodsduck.commons.model.dto.chat.UserChatDto;
 import com.ducks.goodsduck.commons.model.dto.chat.UserChatResponse;
 import com.ducks.goodsduck.commons.model.entity.*;
@@ -31,6 +31,9 @@ public class UserChatService {
     private final UserRepository userRepository;
     private final PriceProposeRepository priceProposeRepository;
     private final ReviewRepository reviewRepository;
+    private final ImageRepository imageRepository;
+    private final ItemImageRepository itemImageRepository;
+    private final ImageRepositoryCustomImpl imageRepositoryCustomImpl;
 
     public Boolean createWithImmediateTrade(String chatId, Long userId, Long itemId) {
 
@@ -108,20 +111,37 @@ public class UserChatService {
         return new UserChatDto(userList, userChatList.get(0).getItem());
     }
 
-    public List<ChatAndItemDto> getChatInfoOfUser(Long userId) {
+    public List<ChatRoomDto> getChatRooms(Long userId) {
 
         List<Tuple> chatAndItemByUserIdTuple = userChatRepositoryCustom.findChatAndItemByUserId(userId);
 
-        List<ChatAndItemDto> chatAndItemList = chatAndItemByUserIdTuple.stream().
+        List<ChatRoomDto> chatAndItemList = chatAndItemByUserIdTuple.stream().
                 map(tuple -> {
                     Chat chat = tuple.get(0, Chat.class);
-                    Item item = tuple.get(1, Item.class);
+                Item item = tuple.get(1, Item.class);
 
-                    return new ChatAndItemDto(chat, item);
+                    return new ChatRoomDto(chat, item);
                 })
                 .collect(Collectors.toList());
 
         return chatAndItemList;
+    }
+
+    public List<ChatRoomDto> getChatRoomsV2(Long userId) {
+
+        List<UserChat> userChats = userChatRepository.findAll();
+
+        return userChats.stream()
+                .map(userChat -> {
+                    Chat chat = userChat.getChat();
+                    Item item = userChat.getItem();
+
+                    User user = userChat.getUser();
+
+                    return new ChatRoomDto(chat, item, user.getNickName());
+                })
+                .collect(Collectors.toList());
+
     }
 
     public String getChatIdByUserIdAndItemOwnerId(Long userId) {


### PR DESCRIPTION
### 추가된 API (**ChatController**)
- 채팅 전송 시 알림 요청 API ([Swagger Link](https://api.goods-duck.com/swagger-ui/index.html#/%EC%B1%84%ED%8C%85%20APIs/sendNotificationUsingPOST))
  - `POST` `/api/v2/chat/notification`
  - `receiverId`에 안읽은 메시지를 저장함.
  -  프론트엔드 상에서 채팅방에 접속 중일 시 호출을 막도록 지정해야 함. (논의 필요)
- 유저가 속한 채팅방 목록 조회 API ([Swagger Link](https://api.goods-duck.com/swagger-ui/index.html#/%EC%B1%84%ED%8C%85%20APIs/getChatRoomsV2UsingGET))
  - `GET` `/api/v2/users/chats`
  - `user:{userId}:chatRoom:{chatRoomId}` 형식의 `key`를 가진 리스트 데이터를 모아서 조회
- 채팅방 접속 시 채팅 읽음 처리 API ([Swagger Link](https://api.goods-duck.com/swagger-ui/index.html#/%EC%B1%84%ED%8C%85%20APIs/readChatMessagesUsingDELETE))
  - `DELETE` `/api/v1/users/chats/{chatRoomId}`  
  - `Redis` DB에서 해당 유저의 `chatRoomId` 채팅방 정보 삭제 (안읽은 메시지)
- 안 읽은 채팅 메시지 여부 조회 API ([Swagger Link](https://api.goods-duck.com/swagger-ui/index.html#/%EC%B1%84%ED%8C%85%20APIs/checkUnreadChatUsingGET))
  - `GET` `/api/v1/users/chats/noty`
  - 로그인한 유저의 안읽은 메시지 존재 여부를 체크함. (true/false 반환)
- 유저가 속해있는 채팅방 정보 획득 API ([Swagger Link](https://api.goods-duck.com/swagger-ui/index.html#/%EC%B1%84%ED%8C%85%20APIs/getChatInfoOfUserV2UsingGET))
  - `GET` `/api/v2/chat`
  - `RDBMS(MySQL)`로 부터 최근 메시지 정보를 제외한 채팅방 목록 데이터를 조회함.

### 변경된 API
- 채팅방 ID를 통해 특정 유저에 대한 리뷰 남기기
  - **ReviewController** `POST` `/api/v1/users/reviews`
  - 로직에 새로 구현된 `notification.sendMessageV2(Notification notification)`을 적용함.
- 가격 제안 요청 API
  - **PriceproposeController** `POST` `/api/v1/items/{itemId}/price-propose`
  - 로직에 새로 구현된 `notification.sendMessageV2(Notification notification)`을 적용함.
