### PR TITLE
[feat] 애플 소셜 로그인 구현 및 Device 허용/차단 여부 설정 보완

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
@@ -30,7 +30,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
@@ -79,6 +78,16 @@ public class UserController {
     public ApiResult<UserDto> authorizeKakao(@RequestParam("code") String code) {
         log.debug("Request code of Kakao's login: " + code);
         return OK(userService.oauth2AuthorizationKakao(code));
+    }
+
+    @NoCheckJwt
+    @ApiOperation("소셜로그인_APPLE 토큰 발급 및 사용자 정보 조회 with 인가코드 API")
+    @GetMapping("/v1/users/login/apple")
+    public ApiResult<UserDto> authorizeApple(@RequestParam("state") String state,
+                                             @RequestParam("code") String code,
+                                             @RequestParam("idToken") String idToken) throws JsonProcessingException {
+        log.debug("Request of Apple's login: \n\tstate: {}, code: {}, idToken: {}", state, code, idToken);
+        return OK(userService.oauth2AuthorizationApple(state, code, idToken));
     }
 
     @NoCheckJwt

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/oauth2/PublicKeyOfApple.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/oauth2/PublicKeyOfApple.java
@@ -1,0 +1,13 @@
+package com.ducks.goodsduck.commons.model.dto.oauth2;
+
+import lombok.Data;
+
+@Data
+public class PublicKeyOfApple {
+    private String kty;
+    private String kid;
+    private String use;
+    private String alg;
+    private String n;
+    private String e;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/oauth2/PublicKeysOfApple.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/oauth2/PublicKeysOfApple.java
@@ -1,0 +1,10 @@
+package com.ducks.goodsduck.commons.model.dto.oauth2;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PublicKeysOfApple {
+    private List<PublicKeyOfApple> keys;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserSimpleDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserSimpleDto.java
@@ -1,6 +1,7 @@
 package com.ducks.goodsduck.commons.model.dto.user;
 
 import com.ducks.goodsduck.commons.model.entity.User;
+import com.ducks.goodsduck.commons.model.enums.UserRole;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -9,12 +10,14 @@ import lombok.NoArgsConstructor;
 public class UserSimpleDto {
 
     private Long userId;
+    private UserRole role;
     private String bcryptId;
     private String nickName;
     private String imageUrl;
 
     public UserSimpleDto(User user) {
         this.userId = user.getId();
+        this.role = user.getRole();
         this.bcryptId = user.getBcryptId();
         this.nickName = user.getNickName();
         this.imageUrl = user.getImageUrl();

--- a/src/main/java/com/ducks/goodsduck/commons/model/enums/SocialType.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/enums/SocialType.java
@@ -1,5 +1,5 @@
 package com.ducks.goodsduck.commons.model.enums;
 
 public enum SocialType {
-    NAVER, KAKAO
+    NAVER, KAKAO, APPLE
 }

--- a/src/main/java/com/ducks/goodsduck/commons/model/enums/UserRole.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/enums/UserRole.java
@@ -1,5 +1,5 @@
 package com.ducks.goodsduck.commons.model.enums;
 
 public enum UserRole {
-    ADMIN, USER, ANONYMOUS
+    ADMIN, USER, ANONYMOUS, RESIGNED
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/DeviceRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/DeviceRepositoryCustomImpl.java
@@ -24,7 +24,7 @@ public class DeviceRepositoryCustomImpl implements DeviceRepositoryCustom {
     public List<String> getRegistrationTokensByUserId(Long userId) {
         return queryFactory.select(device.registrationToken)
                 .from(device)
-                .where(device.user.id.eq(userId))
+                .where(device.user.id.eq(userId).and(device.isAllowed))
                 .fetch();
     }
 

--- a/src/main/java/com/ducks/goodsduck/commons/service/JwtService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/JwtService.java
@@ -1,5 +1,6 @@
 package com.ducks.goodsduck.commons.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -11,4 +12,5 @@ public interface JwtService {
     String getSubject(String token);
     Map<String, Object> getPayloads(String token);
     Map<String, Object> getHeader(String token);
+    Map<String, Object> getHeaderWithoutSignedKey(String token) throws JsonProcessingException;
 }

--- a/src/main/java/com/ducks/goodsduck/commons/util/OauthAppleLoginUtil.java
+++ b/src/main/java/com/ducks/goodsduck/commons/util/OauthAppleLoginUtil.java
@@ -1,0 +1,26 @@
+package com.ducks.goodsduck.commons.util;
+
+import com.ducks.goodsduck.commons.model.dto.oauth2.PublicKeyOfApple;
+import com.ducks.goodsduck.commons.model.dto.oauth2.PublicKeysOfApple;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+public class OauthAppleLoginUtil {
+    private static final RestTemplate restTemplate = new RestTemplate();
+
+    public static List<PublicKeyOfApple> callPublicToken() {
+        try {
+            ResponseEntity<PublicKeysOfApple> response = restTemplate.getForEntity("https://appleid.apple.com/auth/keys", PublicKeysOfApple.class);
+            log.debug("Result of getting access token from Apple: \n" + response.toString());
+            return response.getBody().getKeys();
+        } catch (RestClientException ex) {
+            log.debug("exception occured in request to authorize with Kakao : {}", ex.getMessage(), ex);
+            throw new IllegalStateException();
+        }
+    }
+}


### PR DESCRIPTION
### 추가된 API
- `GET` `/api/v1/users/login/apple`:  애플 소셜 로그인
  - 회원/비회원 검증 및 등록 과정은 기존 `네이버/카카오` 로그인의 경우와 같음

### 수정된 API
- 모든 소셜 로그인
  - 로그인 시 **Device**(RegistrationToken)을 `blank`(""), `isAllowed`(false)로 등록