### PR TITLE
[feat] 아이템 검색 필터링 구현

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/ItemController.java
@@ -10,6 +10,7 @@ import com.ducks.goodsduck.commons.model.dto.item.ItemUploadRequest;
 import com.ducks.goodsduck.commons.model.dto.item.*;
 import com.ducks.goodsduck.commons.model.entity.UserItem;
 import com.ducks.goodsduck.commons.model.enums.GradeStatus;
+import com.ducks.goodsduck.commons.model.enums.Order;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.ducks.goodsduck.commons.model.enums.TradeType;
 import com.ducks.goodsduck.commons.service.*;
@@ -127,15 +128,18 @@ public class ItemController {
     public ApiResult deleteItemV2(@PathVariable("itemId") Long itemId) { return OK(itemService.deleteV2(itemId)); }
 
     @NoCheckJwt
-    @ApiOperation(value = "아이템 검색 (회원/비회원)")
+    @ApiOperation(value = "아이템 검색 (회원/비회원)", notes = "초기 정렬(order)은 최신순(latest), 초기 거래완료(complete)는 보여줌(true)")
     @GetMapping("/v1/items/search")
     @Transactional
     public ApiResult<HomeResponse<ItemHomeResponse>> getSearchedItems(@RequestParam("keyword") String keyword,
                                                                       @RequestParam("itemId") Long itemId,
+                                                                      @RequestParam("order") String stringOrder,
+                                                                      @RequestParam("complete") Boolean complete,
                                                                       @RequestHeader("jwt") String jwt) {
 
         Long userId = userService.checkLoginStatus(jwt);
-        return OK(itemService.getSearchedItemList(userId, keyword, itemId));
+        Order order = Order.valueOf(stringOrder.toUpperCase());
+        return OK(itemService.getSearchedItemList(userId, keyword, itemId, order, complete));
     }
 
     @NoCheckJwt

--- a/src/main/java/com/ducks/goodsduck/commons/model/enums/Order.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/enums/Order.java
@@ -1,0 +1,17 @@
+package com.ducks.goodsduck.commons.model.enums;
+
+public enum Order {
+    LATEST("최신순"),
+    HIGH_PRICE("높은가격순"),
+    LOW_PRICE("낮은가격순");
+
+    private String korName;
+
+    Order(String korName) {
+        this.korName = korName;
+    }
+
+    public String getKorName() {
+        return korName;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/repository/item/ItemRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/item/ItemRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ducks.goodsduck.commons.repository.item;
 import com.ducks.goodsduck.commons.model.dto.ItemFilterDto;
 import com.ducks.goodsduck.commons.model.entity.Item;
 import com.ducks.goodsduck.commons.model.entity.UserIdolGroup;
+import com.ducks.goodsduck.commons.model.enums.Order;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Pageable;
@@ -56,8 +57,8 @@ public interface ItemRepositoryCustom {
     Tuple findItemAndUserByItemId(Long itemId);
 
     // 비회원 - 검색 및 itemId 기반 Limit
-    List<Item> findByKeywordWithLimit(String keyword, Long itemId);
+    List<Item> findByKeywordWithLimit(String keyword, Long itemId, Order order, Boolean complete);
 
     // 회원 - 검색 및 itemId 기반 Limit
-    List<Tuple> findByKeywordWithUserItemAndLimit(Long userId, String keyword, Long itemId);
+    List<Tuple> findByKeywordWithUserItemAndLimit(Long userId, String keyword, Long itemId, Order order, Boolean complete);
 }

--- a/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
+++ b/src/main/java/com/ducks/goodsduck/commons/service/ItemService.java
@@ -18,6 +18,7 @@ import com.ducks.goodsduck.commons.model.entity.Image.Image;
 import com.ducks.goodsduck.commons.model.entity.Image.ItemImage;
 import com.ducks.goodsduck.commons.model.entity.category.ItemCategory;
 import com.ducks.goodsduck.commons.model.enums.ImageType;
+import com.ducks.goodsduck.commons.model.enums.Order;
 import com.ducks.goodsduck.commons.model.enums.TradeStatus;
 import com.ducks.goodsduck.commons.model.enums.TradeType;
 import com.ducks.goodsduck.commons.repository.chat.ChatRepository;
@@ -876,9 +877,9 @@ public class ItemService {
     }
 
     // FEAT: 비회원용 검색 기능
-    public List<ItemHomeResponse> getSearchedItemListForAnonymous(String keyword, Long itemId) {
+    public List<ItemHomeResponse> getSearchedItemListForAnonymous(String keyword, Long itemId, Order order, Boolean complete) {
 
-        List<Item> items = itemRepositoryCustom.findByKeywordWithLimit(keyword, itemId);
+        List<Item> items = itemRepositoryCustom.findByKeywordWithLimit(keyword, itemId, order, complete);
         List<ItemHomeResponse> itemToList =  items
                 .stream()
                 .map(item -> new ItemHomeResponse(item))
@@ -888,7 +889,7 @@ public class ItemService {
     }
 
     // FEAT: 회원용 검색 기능
-    public List<ItemHomeResponse> getSearchedItemListForUser(String keyword, Long userId, Long itemId) {
+    public List<ItemHomeResponse> getSearchedItemListForUser(String keyword, Long userId, Long itemId, Order order, Boolean complete) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundDataException(messageSource.getMessage(NotFoundDataException.class.getSimpleName(),
@@ -896,7 +897,7 @@ public class ItemService {
         user.updateLastLoginAt();
         List<UserIdolGroup> userIdolGroups = user.getUserIdolGroups();
 
-        List<Tuple> listOfTuple = itemRepositoryCustom.findByKeywordWithUserItemAndLimit(userId, keyword, itemId);
+        List<Tuple> listOfTuple = itemRepositoryCustom.findByKeywordWithUserItemAndLimit(userId, keyword, itemId, order, complete);
 
         List<ItemHomeResponse> tupleToList =  listOfTuple
                 .stream()
@@ -925,14 +926,14 @@ public class ItemService {
                 .collect(Collectors.toList());
     }
 
-    public HomeResponse getSearchedItemList(Long userId, String keyword, Long itemId) {
+    public HomeResponse getSearchedItemList(Long userId, String keyword, Long itemId, Order order, Boolean complete) {
 
         int pageableSize = PropertyUtil.PAGEABLE_SIZE;
         Boolean hasNext= false;
 
         // HINT : 비회원에게 보여줄 홈
         if(userId.equals(-1L)) {
-            List<ItemHomeResponse> itemList = getSearchedItemListForAnonymous(keyword, itemId);
+            List<ItemHomeResponse> itemList = getSearchedItemListForAnonymous(keyword, itemId, order, complete);
             if(itemList.size() == pageableSize + 1) {
                 hasNext = true;
                 itemList.remove(pageableSize);
@@ -945,7 +946,7 @@ public class ItemService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new NotFoundDataException(messageSource.getMessage(NotFoundDataException.class.getSimpleName(),
                             new Object[]{"User"}, null)));
-            List<ItemHomeResponse> itemList = getSearchedItemListForUser(keyword, userId, itemId);
+            List<ItemHomeResponse> itemList = getSearchedItemListForUser(keyword, userId, itemId, order, complete);
             if(itemList.size() == pageableSize + 1) {
                 hasNext = true;
                 itemList.remove(pageableSize);


### PR DESCRIPTION
@ApiOperation(value = "아이템 검색 (회원/비회원)")
@GetMapping("/v1/items/search")

기존 쿼리스트링에 order와 complete가 추가되었음
1. order(정렬)의 종류로는 최신순(latest), 높은가격순(high_price), 낮은가격순(low_price)
2. complete(거래완료보기)는 보기(true), 안보기(false)

※ 초기 정렬(order)은 최신순(latest), 초기 거래완료보기(complete)는 보여줌(true)