### PR TITLE
자체 회원가입/로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 	// CoolSMS (authentication of SMS)
 	compile group: 'net.nurigo', name: 'javaSDK', version: '2.2'
 
+	// Security
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security', version: '2.4.5'
+
 	compile('org.springframework.boot:spring-boot-starter-data-redis')
 	compile 'io.sentry:sentry-logback:1.7.30'
 	compile 'io.sentry:sentry-spring-boot-starter:1.7.30'

--- a/src/main/java/com/ducks/goodsduck/commons/config/SecurityConfig.java
+++ b/src/main/java/com/ducks/goodsduck/commons/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.ducks.goodsduck.commons.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.cors().disable()
+                .csrf().disable()
+                .formLogin().disable()
+                .logout().disable()
+                .headers().frameOptions().disable();
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/UserController.java
@@ -12,6 +12,7 @@ import com.ducks.goodsduck.commons.model.dto.notification.NotificationResponse;
 import com.ducks.goodsduck.commons.model.dto.pricepropose.PriceProposeResponse;
 import com.ducks.goodsduck.commons.model.dto.review.TradeCompleteReponse;
 import com.ducks.goodsduck.commons.model.dto.sms.SmsAuthenticationRequest;
+import com.ducks.goodsduck.commons.model.dto.sms.SmsAuthenticationResponse;
 import com.ducks.goodsduck.commons.model.dto.sms.SmsTransmitRequest;
 import com.ducks.goodsduck.commons.model.dto.user.*;
 import com.ducks.goodsduck.commons.model.entity.Item;
@@ -22,7 +23,6 @@ import com.ducks.goodsduck.commons.service.*;
 import com.ducks.goodsduck.commons.util.PropertyUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.Http;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -84,10 +84,31 @@ public class UserController {
     }
 
     @NoCheckJwt
-    @ApiOperation("회원가입 API")
+    @ApiOperation("소셜 회원가입 API")
     @PostMapping("/v1/users/sign-up")
     public ApiResult<UserDto> signUpUser(@RequestBody UserSignUpRequest userSignUpRequest) {
         return OK(userService.signUp(userSignUpRequest));
+    }
+
+    @NoCheckJwt
+    @ApiOperation("자체 회원가입 API V2 (비회원)")
+    @PostMapping("/v2/users/sign-up")
+    public ApiResult<UserDtoV2> signUpUserV2(@RequestBody UserSignUpRequestV2 userSignUpRequest) {
+        return OK(userService.signUpV2(userSignUpRequest));
+    }
+
+    @NoCheckJwt
+    @ApiOperation("자체 로그인 API (비회원)")
+    @PostMapping("/v1/users/login")
+    public ApiResult<UserDtoV2> login(@RequestBody UserLoginRequest userLoginRequest) {
+        return OK(userService.login(userLoginRequest));
+    }
+
+    @NoCheckJwt
+    @ApiOperation("비밀번호 재설정 API (비회원)")
+    @PostMapping("/v1/users/reset-password")
+    public ApiResult<Boolean> resetPassword(@RequestBody UserResetRequest userResetRequest) {
+        return OK(userService.resetPassword(userResetRequest));
     }
 
     @ApiOperation(value = "회원 탈퇴 API", notes = "사용자 권한을 RESIGNED로 수정함")
@@ -145,7 +166,7 @@ public class UserController {
         return OK(userService.updateLikeIdolGroups(userId, userIdolGroupUpdateRequest.getLikeIdolGroupsId()));
     }
 
-    //TODO: jwt를 클라이언트에서 사용하고 있는지 확인 필요
+    // TODO: jwt를 클라이언트에서 사용하고 있는지 확인 필요
     @NoCheckJwt
     @ApiOperation("jwt를 통한 유저 정보 조회 API")
     @GetMapping("/v1/users/look-up")
@@ -280,6 +301,15 @@ public class UserController {
         String phoneNumber = smsAuthenticationRequest.getPhoneNumber();
         String authenticationNumber = smsAuthenticationRequest.getAuthenticationNumber();
         return OK(smsAuthenticationService.authenticate(phoneNumber, authenticationNumber));
+    }
+
+    @NoCheckJwt
+    @PostMapping("/v1/sms/authentication-find")
+    @ApiOperation("SMS 인증 번호에 대한 검증 for 이메일/비밀번호 찾기 (비회원)")
+    public ApiResult<SmsAuthenticationResponse> authenticateBySmsForFind(@RequestBody SmsAuthenticationRequest smsAuthenticationRequest) {
+        String phoneNumber = smsAuthenticationRequest.getPhoneNumber();
+        String authenticationNumber = smsAuthenticationRequest.getAuthenticationNumber();
+        return OK(smsAuthenticationService.authenticateForFind(phoneNumber, authenticationNumber));
     }
 
     @GetMapping("/v1/users/address")

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/sms/SmsAuthenticationResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/sms/SmsAuthenticationResponse.java
@@ -1,0 +1,15 @@
+package com.ducks.goodsduck.commons.model.dto.sms;
+
+import lombok.Data;
+
+@Data
+public class SmsAuthenticationResponse {
+
+    boolean success;
+    private String email;
+
+    public SmsAuthenticationResponse(boolean success, String email) {
+        this.success = success;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserDtoV2.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserDtoV2.java
@@ -13,10 +13,10 @@ import java.util.stream.Collectors;
 
 @Data
 @NoArgsConstructor
-public class UserDto {
+public class UserDtoV2 {
 
-    private SocialType socialType;
-    private String socialAccountId;
+    private Boolean emailSuccess;
+    private Boolean passwordSuccess;
     private String bcryptId;
     private String nickName;
     private String phoneNumber;
@@ -32,17 +32,11 @@ public class UserDto {
     private LocalDateTime lastLoginAt;
     private LocalDateTime deletedAt;
 
-    public static UserDto createUserDto(UserRole role) {
-        UserDto userDto = new UserDto();
-        userDto.setRole(role);
-        return userDto;
-    }
-
     public void setAgreeToNotification(Boolean isAgree) {
         this.isAgreeToNotification = isAgree;
     }
 
-    public UserDto(User user) {
+    public UserDtoV2(User user) {
         this.nickName = user.getNickName();
         this.phoneNumber = user.getPhoneNumber();
         this.email = user.getEmail();

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserLoginRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserLoginRequest.java
@@ -1,0 +1,10 @@
+package com.ducks.goodsduck.commons.model.dto.user;
+
+import lombok.Data;
+
+@Data
+public class UserLoginRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserLoginResponse.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserLoginResponse.java
@@ -1,0 +1,15 @@
+package com.ducks.goodsduck.commons.model.dto.user;
+
+import lombok.Data;
+
+@Data
+public class UserLoginResponse {
+
+    Boolean emailSuccess;
+    Boolean passwordSuccess;
+
+    public UserLoginResponse(Boolean emailSuccess, Boolean passwordSuccess) {
+        this.emailSuccess = emailSuccess;
+        this.passwordSuccess = passwordSuccess;
+    }
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserResetRequest.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserResetRequest.java
@@ -1,0 +1,10 @@
+package com.ducks.goodsduck.commons.model.dto.user;
+
+import lombok.Data;
+
+@Data
+public class UserResetRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserSignUpRequestV2.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/user/UserSignUpRequestV2.java
@@ -1,0 +1,22 @@
+package com.ducks.goodsduck.commons.model.dto.user;
+
+import com.ducks.goodsduck.commons.model.enums.SocialType;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 회원 가입 시
+ * 소셜 로그인 정보 + 닉네임, 이메일, 핸드폰 번호 입력 받는 DTO
+ */
+
+@Data
+public class UserSignUpRequestV2 {
+
+    private String email;
+    private String password;
+    private String phoneNumber;
+    private String nickName;
+    private List<Long> likeIdolGroupsId = new ArrayList<>();
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/User.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/User.java
@@ -24,6 +24,7 @@ public class User {
     private String bcryptId;
     private String nickName;
     private String email;
+    private String password;
     private String phoneNumber;
     private String imageUrl;
     private Integer level;
@@ -32,6 +33,7 @@ public class User {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime lastLoginAt;
+    private LocalDateTime deletedAt;
 
     @Enumerated(EnumType.STRING)
     private UserRole role;


### PR DESCRIPTION
**@ApiOperation("자체 회원가입 API V2 (비회원)")
@PostMapping("/v2/users/sign-up")**

**@ApiOperation("자체 로그인 API (비회원)")
@PostMapping("/v1/users/login")**
-> emailSuccess : 이메일이 존재하지 않는 경우 false
-> passwordSuccess : 패스워드가 틀린 경우 false, 이때 email 먼저 검증하므로 emailSuccess는 true

**@ApiOperation("비밀번호 재설정 API (비회원)")
@PostMapping("/v1/users/reset-password")**

**@PostMapping("/v1/sms/authentication-find")
@ApiOperation("SMS 인증 번호에 대한 검증 for 이메일/비밀번호 찾기 (비회원)")**
-> 단순 SMS 인증 번호에 대한 검증 API(v1/sms/authentication)에서는 Boolean 타입만 주었으나, 추가적으로 Email 리턴

