### PR TITLE
[refactor & feat] 댓글 관련 API 구현

### DIFF
--- a/src/main/java/com/ducks/goodsduck/commons/config/Scheduler.java
+++ b/src/main/java/com/ducks/goodsduck/commons/config/Scheduler.java
@@ -3,6 +3,7 @@ package com.ducks.goodsduck.commons.config;
 import com.ducks.goodsduck.commons.model.entity.*;
 import com.ducks.goodsduck.commons.model.entity.Image.Image;
 import com.ducks.goodsduck.commons.model.entity.Image.ItemImage;
+import com.ducks.goodsduck.commons.model.entity.Image.PostImage;
 import com.ducks.goodsduck.commons.model.enums.ImageType;
 import com.ducks.goodsduck.commons.repository.category.ItemCategoryRepository;
 import com.ducks.goodsduck.commons.repository.chat.ChatRepository;
@@ -14,6 +15,7 @@ import com.ducks.goodsduck.commons.repository.image.ItemImageRepository;
 import com.ducks.goodsduck.commons.repository.image.ProfileImageRepository;
 import com.ducks.goodsduck.commons.repository.item.ItemRepository;
 import com.ducks.goodsduck.commons.repository.item.ItemRepositoryCustom;
+import com.ducks.goodsduck.commons.repository.post.PostRepository;
 import com.ducks.goodsduck.commons.repository.post.UserPostRepository;
 import com.ducks.goodsduck.commons.repository.pricepropose.PriceProposeRepository;
 import com.ducks.goodsduck.commons.repository.pricepropose.PriceProposeRepositoryCustom;
@@ -57,6 +59,7 @@ public class Scheduler {
     private final ItemImageRepository itemImageRepository;
     private final UserIdolGroupRepository userIdolGroupRepository;
     private final UserPostRepository userPostRepository;
+    private final PostRepository postRepository;
 
     private final ImageUploadService imageUploadService;
 
@@ -163,6 +166,52 @@ public class Scheduler {
                 deleteUser.setNickName("탈퇴한 사용자");
                 deleteUser.setImageUrl(PropertyUtil.BASIC_IMAGE_URL);
                 deleteUser.setLevel(1);
+            }
+        }
+    }
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void postDelete() {
+
+        List<Post> deletePosts = postRepository.findAllWithDeleted();
+
+        for (Post deletePost : deletePosts) {
+
+            // HINT : 30일 지난 후 삭제
+            if(deletePost.getDeletedAt().plusDays(30).isBefore(LocalDateTime.now())) {
+
+                log.info("cron delete post : " + deletePost.getId());
+
+                // image 연관 삭제
+//                List<Image> deleteImages = (List<Image>)deletePost.getImages();
+//                for (PostImage deleteImage : deleteImages) {
+//                    imageUploadService.deleteImage(deleteImage, ImageType.POST);
+//                }
+//                postImageRepository.deleteInBatch(deleteImages);
+
+
+
+//                if(!deletePost.getImageUrl().equals(PropertyUtil.BASIC_IMAGE_URL)) {
+//                    Image deleteImage = imageRepository.findByUrl(deleteUser.getImageUrl());
+//                    imageUploadService.deleteImage(deleteImage, ImageType.PROFILE);
+//                    imageRepository.delete(deleteImage);
+//                }
+
+                // pricePropose 연관 삭제
+//                List<PricePropose> deletePriceProposes = priceProposeRepositoryCustom.findAllByUserIdWithAllStatus(deleteUser.getId());
+//                priceProposeRepository.deleteInBatch(deletePriceProposes);
+//
+//                // userChat 연관 삭제
+//                List<UserChat> deleteUserChats = userChatRepository.findByUserId(deleteUser.getId());
+//                userChatRepository.deleteInBatch(deleteUserChats);
+//
+//                // chat 삭제
+//                List<Chat> deleteChats = new ArrayList<>();
+//                for (UserChat deleteUserChat : deleteUserChats) {
+//                    deleteChats.add(deleteUserChat.getChat());
+//                }
+//                chatRepository.deleteInBatch(deleteChats);
+
             }
         }
     }

--- a/src/main/java/com/ducks/goodsduck/commons/controller/CommentController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/CommentController.java
@@ -2,10 +2,7 @@ package com.ducks.goodsduck.commons.controller;
 
 import com.ducks.goodsduck.commons.annotation.NoCheckJwt;
 import com.ducks.goodsduck.commons.model.dto.ApiResult;
-import com.ducks.goodsduck.commons.model.dto.comment.CommentDto;
-import com.ducks.goodsduck.commons.model.dto.comment.CommentSimpleDto;
-import com.ducks.goodsduck.commons.model.dto.comment.CommentUpdateRequest;
-import com.ducks.goodsduck.commons.model.dto.comment.CommentUploadRequest;
+import com.ducks.goodsduck.commons.model.dto.comment.*;
 import com.ducks.goodsduck.commons.service.CommentService;
 import com.ducks.goodsduck.commons.util.PropertyUtil;
 import io.swagger.annotations.Api;
@@ -40,9 +37,17 @@ public class CommentController {
     @ApiOperation(value = "댓글 업로드 API V2")
     @PostMapping("/v2/comments")
     public ApiResult<Long> uploadCommentV2(@RequestBody CommentUploadRequest commentUploadRequest,
-                                         HttpServletRequest request) {
+                                           HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(commentService.uploadCommentV2(commentUploadRequest, userId));
+    }
+
+    @ApiOperation(value = "댓글 업로드 API V3")
+    @PostMapping("/v3/comments")
+    public ApiResult<Long> uploadCommentV3(@RequestBody CommentUploadRequestV2 commentUploadRequest,
+                                           HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(commentService.uploadCommentV3(commentUploadRequest, userId));
     }
 
     @ApiOperation(value = "댓글 수정 API")
@@ -59,7 +64,7 @@ public class CommentController {
         return OK(commentService.deleteComment(userId, commentId));
     }
 
-    @ApiOperation(value = "(임시) 댓글 삭제 API V2")
+    @ApiOperation(value = "댓글 삭제 API V2")
     @DeleteMapping("/v2/comments/{commentId}")
     public ApiResult<Long> deleteCommentV2(@PathVariable("commentId") Long commentId, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
@@ -68,24 +73,28 @@ public class CommentController {
 
     @ApiOperation(value = "관련 포스트의 댓글 목록 조회 API")
     @GetMapping("/v1/comments/{postId}")
-    public ApiResult<List<CommentDto>> showCommentsOfPost(@PathVariable("postId") Long postId,
-                                                          HttpServletRequest request) {
+    public ApiResult<List<CommentDto>> showCommentsOfPost(@PathVariable("postId") Long postId, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(commentService.getCommentsOfPost(userId, postId));
     }
 
     @ApiOperation(value = "관련 포스트의 댓글 목록 조회 API V2")
     @GetMapping("/v2/comments/{postId}")
-    public ApiResult<List<CommentSimpleDto>> showCommentsOfPostV2(@PathVariable("postId") Long postId,
-                                                                  HttpServletRequest request) {
+    public ApiResult<List<CommentSimpleDto>> showCommentsOfPostV2(@PathVariable("postId") Long postId, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(commentService.getCommentsOfPostV2(userId, postId));
     }
 
+    @ApiOperation(value = "관련 포스트의 댓글 목록 조회 API V3")
+    @GetMapping("/v3/comments/{postId}")
+    public ApiResult<List<CommentDto>> showCommentsOfPostV3(@PathVariable("postId") Long postId, HttpServletRequest request) {
+        Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
+        return OK(commentService.getCommentsOfPostV3(userId, postId));
+    }
+
     @ApiOperation(value = "일반댓글 <-> 비밀댓글 변경 API")
     @GetMapping("/v1/comments/{commentId}/change-state")
-    public ApiResult<Boolean> changeCommentState(@PathVariable("commentId") Long commentId,
-                                                                HttpServletRequest request) {
+    public ApiResult<Boolean> changeCommentState(@PathVariable("commentId") Long commentId, HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(commentService.changeCommentState(userId, commentId));
     }

--- a/src/main/java/com/ducks/goodsduck/commons/controller/CommunityController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/CommunityController.java
@@ -62,7 +62,7 @@ public class CommunityController {
     @GetMapping("/v1/community/free-market/filter")
     @ApiOperation("무료나눔장터 포스트 목록 조회 + 특정 아이돌 그룹 필터링 API (회원)")
     public ApiResult<HomeResponse<PostDetailResponse>> getFreeMarket(@RequestParam("postId") Long postId,
-                                                                     @RequestParam("idolGroupId") Long idolGroupId,
+                                                                     @RequestParam("idolGroup") Long idolGroupId,
                                                                      HttpServletRequest request) {
         Long userId = (Long) request.getAttribute(PropertyUtil.KEY_OF_USERID_IN_JWT_PAYLOADS);
         return OK(communityService.getFreePostListFilterByIdolGroup(userId, idolGroupId, postId));

--- a/src/main/java/com/ducks/goodsduck/commons/controller/PostController.java
+++ b/src/main/java/com/ducks/goodsduck/commons/controller/PostController.java
@@ -74,7 +74,7 @@ public class PostController {
     @ApiOperation("포스트 삭제 V2 API")
     @DeleteMapping("/v2/posts/{postId}")
     public ApiResult<Long> deletePostV2(@PathVariable("postId") Long postId) {
-        return OK(postService.delete(postId));
+        return OK(postService.deleteV2(postId));
     }
 
     @ApiOperation("특정 포스트 좋아요 요청 API")

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/comment/CommentSimpleDto.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/comment/CommentSimpleDto.java
@@ -4,6 +4,8 @@ import com.ducks.goodsduck.commons.model.dto.user.UserSimpleDto;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 public class CommentSimpleDto {

--- a/src/main/java/com/ducks/goodsduck/commons/model/dto/comment/CommentUploadRequestV2.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/dto/comment/CommentUploadRequestV2.java
@@ -1,0 +1,12 @@
+package com.ducks.goodsduck.commons.model.dto.comment;
+
+import lombok.Data;
+
+@Data
+public class CommentUploadRequestV2 {
+
+    private String content;
+    private Long postId;
+    private Long receiveCommentId;
+    private Boolean isSecret;
+}

--- a/src/main/java/com/ducks/goodsduck/commons/model/entity/Comment.java
+++ b/src/main/java/com/ducks/goodsduck/commons/model/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.ducks.goodsduck.commons.model.entity;
 
 import com.ducks.goodsduck.commons.model.dto.comment.CommentUploadRequest;
+import com.ducks.goodsduck.commons.model.dto.comment.CommentUploadRequestV2;
 import lombok.*;
 
 import javax.persistence.*;
@@ -16,11 +17,13 @@ public class Comment {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "comment_id")
     private Long id;
+    private Long receiveCommentId;
     private Integer level;
     private Boolean isDeleted;
     private Boolean isSecret;
     private String content;
     private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -37,6 +40,7 @@ public class Comment {
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE)
     private List<Comment> childComments = new ArrayList<>();
 
+    // v1
     public Comment(User user, Post post, Comment parentComment, CommentUploadRequest commentUploadRequest) {
         this.user = user;
         this.post = post;
@@ -48,11 +52,24 @@ public class Comment {
         this.createdAt = LocalDateTime.now();
     }
 
+    // v2
     public Comment(User user, Post post, Comment parentComment, CommentUploadRequest commentUploadRequest, Boolean V2) {
         this.user = user;
         this.post = post;
         this.parentComment = parentComment;
         this.level = parentComment != null ? 2 : 1;
+        this.isDeleted = false;
+        this.isSecret = commentUploadRequest.getIsSecret();
+        this.content = commentUploadRequest.getContent();
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // v3
+    public Comment(User user, Post post, Comment receiveComment, CommentUploadRequestV2 commentUploadRequest) {
+        this.user = user;
+        this.post = post;
+        this.receiveCommentId = commentUploadRequest.getReceiveCommentId() != 0 ? commentUploadRequest.getReceiveCommentId() : null;
+        this.level = commentUploadRequest.getReceiveCommentId() != 0 ? 2 : 1;
         this.isDeleted = false;
         this.isSecret = commentUploadRequest.getIsSecret();
         this.content = commentUploadRequest.getContent();

--- a/src/main/java/com/ducks/goodsduck/commons/repository/comment/CommentRepositoryCustom.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/comment/CommentRepositoryCustom.java
@@ -8,7 +8,11 @@ import java.util.List;
 @Repository
 public interface CommentRepositoryCustom {
 
+    // 댓글 목록 조회 V1, V2
     List<Comment> findAllByPostId(Long postId);
+
+    // 댓글 목록 조회 V3
+    List<Comment> findTopCommentsByPostId(Long postId);
     
     // 내가 작성한 댓글 목록 조회
     List<Comment> findByUserId(Long userId, Long commentId);

--- a/src/main/java/com/ducks/goodsduck/commons/repository/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/comment/CommentRepositoryCustomImpl.java
@@ -34,6 +34,16 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
     }
 
     @Override
+    public List<Comment> findTopCommentsByPostId(Long postId) {
+        return queryFactory
+                .select(comment)
+                .from(comment)
+                .where(comment.post.id.eq(postId).and(comment.receiveCommentId.isNull()))
+                .orderBy(comment.createdAt.asc())
+                .fetch();
+    }
+
+    @Override
     public List<Comment> findByUserId(Long userId, Long commentId) {
 
         BooleanBuilder builder = new BooleanBuilder();
@@ -45,7 +55,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
         return queryFactory
                 .select(comment)
                 .from(comment)
-                .where(builder.and(comment.user.id.eq(userId)))
+                .where(builder.and(comment.user.id.eq(userId)).and(comment.deletedAt.isNull()))
                 .orderBy(comment.id.desc())
                 .limit(PropertyUtil.POST_PAGEABLE_SIZE + 1)
                 .fetch();

--- a/src/main/java/com/ducks/goodsduck/commons/repository/post/PostRepository.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/post/PostRepository.java
@@ -2,6 +2,7 @@ package com.ducks.goodsduck.commons.repository.post;
 
 import com.ducks.goodsduck.commons.model.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +11,7 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByUserId(Long userId);
+
+    @Query("select p from Post p where p.deletedAt is not null")
+    List<Post> findAllWithDeleted();
 }

--- a/src/main/java/com/ducks/goodsduck/commons/repository/post/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/ducks/goodsduck/commons/repository/post/PostRepositoryCustomImpl.java
@@ -133,7 +133,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
         return queryFactory
                 .select(post)
                 .from(post)
-                .where(builder.and(post.user.id.eq(userId)))
+                .where(builder.and(post.user.id.eq(userId)).and(post.deletedAt.isNull()))
                 .orderBy(post.id.desc())
                 .limit(PropertyUtil.POST_PAGEABLE_SIZE + 1)
                 .fetch();
@@ -152,7 +152,7 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .select(post)
                 .from(post)
                 .innerJoin(userPost).on(userPost.user.id.eq(userId), userPost.post.id.eq(post.id))
-                .where(builder)
+                .where(builder.and(userPost.deletedAt.isNull()))
                 .orderBy(post.id.desc())
                 .limit(PropertyUtil.POST_PAGEABLE_SIZE + 1)
                 .fetch();

--- a/src/main/java/com/ducks/goodsduck/commons/util/PropertyUtil.java
+++ b/src/main/java/com/ducks/goodsduck/commons/util/PropertyUtil.java
@@ -9,7 +9,7 @@ public class PropertyUtil {
     public static final String SUBJECT_OF_JWT = "For Member-Checking";
     public static final String KEY_OF_USERID_IN_JWT_PAYLOADS = "userId";
     public static final Integer PAGEABLE_SIZE = 20;
-    public static final Integer POST_PAGEABLE_SIZE = 3;
+    public static final Integer POST_PAGEABLE_SIZE = 10;
     public static final String BASIC_IMAGE_URL = "https://goodsduck-s3.s3.ap-northeast-2.amazonaws.com/sample_goodsduck.png";
 
     public static String getProperty(String propertyName) {


### PR DESCRIPTION
**@ApiOperation(value = "댓글 업로드 API V3")**
``@PostMapping("/v3/comments")``
: 요청 JSON 속성의 parentCommentId -> receiveCommentId 변수 이름 변경

**@ApiOperation(value = "댓글 삭제 API V2")**
``@DeleteMapping("/v2/comments/{commentId}")``

**@ApiOperation(value = "관련 포스트의 댓글 목록 조회 API V3")**
``@GetMapping("/v3/comments/{postId}")``
: response 변경 -> 대댓글 목록을 childComments로 주는 것으로 변경